### PR TITLE
New UMP-pcPL map provided added

### DIFF
--- a/GMap.NET.Core/GMap.NET.Core.csproj
+++ b/GMap.NET.Core/GMap.NET.Core.csproj
@@ -287,6 +287,7 @@
     <Compile Include="GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapQuestProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\OpenStreetMap\OpenCycleTransportMapProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\OpenStreetMap\OpenCycleLandscapeMapProvider.cs" />
+    <Compile Include="GMap.NET.MapProviders\UMP\UMPMapProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\Yandex\YandexHybridMapProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\Yandex\YandexSatelliteMapProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\Yandex\YandexMapProvider.cs" />

--- a/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
@@ -160,6 +160,7 @@ namespace GMap.NET.MapProviders
         public static readonly ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_MapProvider ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_Map = ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_MapProvider.Instance;
 
         public static readonly SwedenMapProvider SwedenMap = SwedenMapProvider.Instance;
+        public static readonly UMPMapProvider UMPMap = UMPMapProvider.Instance;
 
         static List<GMapProvider> list;
 

--- a/GMap.NET.Core/GMap.NET.MapProviders/UMP/UMPMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/UMP/UMPMapProvider.cs
@@ -1,0 +1,93 @@
+﻿
+namespace GMap.NET.MapProviders
+{
+    using GMap.NET.Projections;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Xml;
+
+    /// <summary>
+    /// UMP-pcPL map Provider
+    /// http://ump.waw.pl/en/index.html
+    /// 
+    /// UMP-pcPL – is a free map dedicated for Garmin GPS devices, developed by users.You can find a plenty of such maps(others than ours) which cover different areas of the world on Mapcenter and Mapcenter2,
+    /// or using search service.
+    /// UMP-pcPL covers "almost whole" Poland, and therefore we call it "pcPL" (prawie cała PL). Almost – because we have not finished nor completed it yet, and the map is continuously growing.
+    /// Other countries are also included
+    /// Added by Lukasz Knap
+    /// </summary>
+    public class UMPMapProvider : GMapProvider
+    {
+        public static readonly UMPMapProvider Instance;
+
+        UMPMapProvider()
+        {
+            RefererUrl = "http://ump.waw.pl/";
+            Copyright = "Data by UMP-pcPL";
+        }
+
+        static UMPMapProvider()
+        {
+            Instance = new UMPMapProvider();
+        }
+
+        #region GMapProvider Members
+
+        readonly Guid id = new Guid("E36E311E-256A-4639-9AF7-FEB7BDEA6ABE");
+        public override Guid Id
+        {
+            get
+            {
+                return id;
+            }
+        }
+
+        readonly string name = "UMP";
+        public override string Name
+        {
+            get
+            {
+                return name;
+            }
+        }
+
+        public override PureProjection Projection
+        {
+            get
+            {
+                return MercatorProjection.Instance;
+            }
+        }
+
+        GMapProvider[] overlays;
+        public override GMapProvider[] Overlays
+        {
+            get
+            {
+                if (overlays == null)
+                {
+                    overlays = new GMapProvider[] { this };
+                }
+                return overlays;
+            }
+        }
+
+        public override PureImage GetTileImage(GPoint pos, int zoom)
+        {
+            string url = MakeTileImageUrl(pos, zoom, string.Empty);
+
+            return GetTileImageUsingHttp(url);
+        }
+
+        #endregion
+
+        string MakeTileImageUrl(GPoint pos, int zoom, string language)
+        {
+            return string.Format(UrlFormat, zoom, pos.X, pos.Y);
+        }
+
+        static readonly string UrlFormat = "http://tiles.ump.waw.pl/ump_tiles/{0}/{1}/{2}.png";
+    }
+}


### PR DESCRIPTION
UMP-pcPL map provider has been added.
It's based on free map [http://ump.waw.pl/en/index.html](url)