### PR TITLE
Update MapRoute.cs

### DIFF
--- a/GMap.NET/GMap.NET.Core/GMap.NET/MapRoute.cs
+++ b/GMap.NET/GMap.NET.Core/GMap.NET/MapRoute.cs
@@ -123,7 +123,7 @@ namespace GMap.NET
                     }
                 }
 
-                return Math.Round(distance, 1);
+                return Math.Round(distance, 4);
             }
         }
         


### PR DESCRIPTION
Brings distance rounding in line with the Overpass Ways length. 
The current rounding setting makes version 1.9.x unusable for OSM applications.