### PR TITLE
Added methods that allow for background rendering of WPF map controls

### DIFF
--- a/GMap.NET/GMap.NET.Core/GMap.NET.Internals/Core.cs
+++ b/GMap.NET/GMap.NET.Core/GMap.NET.Internals/Core.cs
@@ -1,4 +1,7 @@
 ﻿
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace GMap.NET.Internals
 {
     using System;
@@ -627,6 +630,28 @@ namespace GMap.NET.Internals
             {
                 throw new Exception("Please, do not call ReloadMap before form is loaded, it's useless");
             }
+        }
+
+        public Task ReloadMapAsync()
+        {
+            ReloadMap();
+            return Task.Factory.StartNew(() =>
+            {
+                bool wait;
+                do
+                {
+                    Thread.Sleep(100);
+                    Monitor.Enter(tileLoadQueue);
+                    try
+                    {
+                        wait = tileLoadQueue.Any();
+                    }
+                    finally
+                    {
+                        Monitor.Exit(tileLoadQueue);
+                    }
+                } while (wait);
+            });
         }
 
         /// <summary>

--- a/GMap.NET/GMap.NET.WindowsPresentation/GMap.NET.WindowsPresentation/GMapControl.cs
+++ b/GMap.NET/GMap.NET.WindowsPresentation/GMap.NET.WindowsPresentation/GMapControl.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Threading.Tasks;
+
 namespace GMap.NET.WindowsPresentation
 {
     using System;
@@ -765,6 +767,43 @@ namespace GMap.NET.WindowsPresentation
             {
                 InvalidateVisual();
             }
+        }
+
+        public void InitializeForBackgroundRendering(int width, int height)
+        {
+            Width = width;
+            Height = height;
+
+            if (!Core.IsStarted)
+            {
+                if (lazyEvents)
+                {
+                    lazyEvents = false;
+
+                    if (lazySetZoomToFitRect.HasValue)
+                    {
+                        SetZoomToFitRect(lazySetZoomToFitRect.Value);
+                        lazySetZoomToFitRect = null;
+                    }
+                }
+
+                Core.OnMapOpen();
+                ForceUpdateOverlays();
+            }
+
+            Core.OnMapSizeChanged(width, height);
+
+            if (Core.IsStarted)
+            {
+                if (IsRotated)
+                {
+                    UpdateRotationMatrix();
+                }
+
+                ForceUpdateOverlays();
+            }
+
+            UpdateLayout();
         }
 
         /// <summary>
@@ -2384,6 +2423,11 @@ namespace GMap.NET.WindowsPresentation
         public void ReloadMap()
         {
             Core.ReloadMap();
+        }
+
+        public Task ReloadMapAsync()
+        {
+            return Core.ReloadMapAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
Background thread rendering is now possible on STA threads by calling the InitializeForBackgroundRendering method on the GMapControl. Title loading can also be awaited using the ReloadMapAsync method.

Attached to the PR is an [ example console application](https://github.com/judero01col/GMap.NET/files/3174850/MapRenderTest.zip) that uses this method for saving a jpg in a background thread.
