### PR TITLE
Add default image proxy class

### DIFF
--- a/Demo/Demo.WindowsPresentation/Windows/MainWindow.xaml.cs
+++ b/Demo/Demo.WindowsPresentation/Windows/MainWindow.xaml.cs
@@ -58,7 +58,6 @@ namespace Demo.WindowsPresentation
          }
 
          GoogleMapProvider.Instance.ApiKey = Stuff.GoogleMapsApiKey;
-         GMapProvider.WebProxy = WebRequest.DefaultWebProxy;
 
          // config map
          MainMap.MapProvider = GMapProviders.OpenStreetMap;

--- a/Demo/Demo.WindowsPresentation/Windows/MainWindow.xaml.cs
+++ b/Demo/Demo.WindowsPresentation/Windows/MainWindow.xaml.cs
@@ -58,6 +58,7 @@ namespace Demo.WindowsPresentation
          }
 
          GoogleMapProvider.Instance.ApiKey = Stuff.GoogleMapsApiKey;
+         GMapProvider.WebProxy = WebRequest.DefaultWebProxy;
 
          // config map
          MainMap.MapProvider = GMapProviders.OpenStreetMap;

--- a/GMap.NET/GMap.NET.Core/.editorconfig
+++ b/GMap.NET/GMap.NET.Core/.editorconfig
@@ -1,0 +1,124 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+# All files
+[*]
+indent_style = space
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 3
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+###############################
+# VB Coding Conventions       #
+###############################
+[*.vb]
+# Modifier preferences
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/GMap.NET/GMap.NET.Core/GMap.NET.Internals/PureImage.cs
+++ b/GMap.NET/GMap.NET.Core/GMap.NET.Internals/PureImage.cs
@@ -1,31 +1,26 @@
-﻿
+﻿using System;
+using System.IO;
+
 namespace GMap.NET
 {
-   using System;
-   using System.IO;
-
    /// <summary>
    /// image abstraction proxy
    /// </summary>
    public abstract class PureImageProxy
    {
-      abstract public PureImage FromStream(Stream stream);
-      abstract public bool Save(Stream stream, PureImage image);
+      public abstract PureImage FromStream(Stream stream);
+
+      public abstract bool Save(Stream stream, PureImage image);
 
       public PureImage FromArray(byte[] data)
       {
-         MemoryStream m = new MemoryStream(data, 0, data.Length, false, true);
+         var m = new MemoryStream(data, 0, data.Length, false, true);
          var pi = FromStream(m);
-         if(pi != null)
+         if (pi != null)
          {
             m.Position = 0;
             pi.Data = m;
          }
-         else
-         {
-            m.Dispose();
-         }
-         m = null;
 
          return pi;
       }
@@ -48,5 +43,38 @@ namespace GMap.NET
       public abstract void Dispose();
 
       #endregion
+   }
+
+   public class DefaultImageProxy : PureImageProxy
+   {
+      public static readonly DefaultImageProxy Instance = new DefaultImageProxy();
+
+      private DefaultImageProxy()
+      {
+      }
+
+      public override PureImage FromStream(Stream stream)
+      {
+         return new DefaultImage();
+      }
+
+      public override bool Save(Stream stream, PureImage image)
+      {
+         if (image.Data != null)
+         {
+            image.Data.WriteTo(stream);
+            image.Data.Position = 0;
+            return true;
+         }
+
+         return false;
+      }
+
+      private class DefaultImage : PureImage
+      {
+         public override void Dispose()
+         {
+         }
+      }
    }
 }

--- a/GMap.NET/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
+++ b/GMap.NET/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
@@ -1,71 +1,71 @@
 ﻿
 namespace GMap.NET.MapProviders
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.IO;
-    using System.Net;    
-    using GMap.NET.Internals;
-    using GMap.NET.Projections;
-    using System.Text;
-    using System.Security.Cryptography;
+   using System;
+   using System.Collections.Generic;
+   using System.Diagnostics;
+   using System.IO;
+   using System.Net;
+   using GMap.NET.Internals;
+   using GMap.NET.Projections;
+   using System.Text;
+   using System.Security.Cryptography;
 
-    /// <summary>
-    /// providers that are already build in
-    /// </summary>
-    public class GMapProviders
-    {
-        static GMapProviders()
-        {
-            list = new List<GMapProvider>();
+   /// <summary>
+   /// providers that are already build in
+   /// </summary>
+   public class GMapProviders
+   {
+      static GMapProviders()
+      {
+         list = new List<GMapProvider>();
 
-            Type type = typeof(GMapProviders);
+         Type type = typeof(GMapProviders);
 
-            foreach (var p in type.GetFields())
+         foreach (var p in type.GetFields())
+         {
+            var v = p.GetValue(null) as GMapProvider; // static classes cannot be instanced, so use null...
+            if (v != null)
             {
-                var v = p.GetValue(null) as GMapProvider; // static classes cannot be instanced, so use null...
-                if (v != null)
-                {
-                    list.Add(v);
-                }
+               list.Add(v);
             }
+         }
 
-            Hash = new Dictionary<Guid, GMapProvider>();
+         Hash = new Dictionary<Guid, GMapProvider>();
 
-            foreach (var p in list)
-            {
-                Hash.Add(p.Id, p);
-            }
+         foreach (var p in list)
+         {
+            Hash.Add(p.Id, p);
+         }
 
-            DbHash = new Dictionary<int, GMapProvider>();
+         DbHash = new Dictionary<int, GMapProvider>();
 
-            foreach (var p in list)
-            {
-                DbHash.Add(p.DbId, p);
-            }
-        }
+         foreach (var p in list)
+         {
+            DbHash.Add(p.DbId, p);
+         }
+      }
 
-        GMapProviders()
-        {
+      GMapProviders()
+      {
 
-        }
+      }
 
-        public static readonly EmptyProvider EmptyProvider = EmptyProvider.Instance;
+      public static readonly EmptyProvider EmptyProvider = EmptyProvider.Instance;
 
-        public static readonly OpenStreetMapProvider OpenStreetMap = OpenStreetMapProvider.Instance;
+      public static readonly OpenStreetMapProvider OpenStreetMap = OpenStreetMapProvider.Instance;
 
-        public static readonly OpenStreet4UMapProvider OpenStreet4UMap = OpenStreet4UMapProvider.Instance;
+      public static readonly OpenStreet4UMapProvider OpenStreet4UMap = OpenStreet4UMapProvider.Instance;
 
-        public static readonly OpenCycleMapProvider OpenCycleMap = OpenCycleMapProvider.Instance;
-        public static readonly OpenCycleLandscapeMapProvider OpenCycleLandscapeMap = OpenCycleLandscapeMapProvider.Instance;
-        public static readonly OpenCycleTransportMapProvider OpenCycleTransportMap = OpenCycleTransportMapProvider.Instance;
+      public static readonly OpenCycleMapProvider OpenCycleMap = OpenCycleMapProvider.Instance;
+      public static readonly OpenCycleLandscapeMapProvider OpenCycleLandscapeMap = OpenCycleLandscapeMapProvider.Instance;
+      public static readonly OpenCycleTransportMapProvider OpenCycleTransportMap = OpenCycleTransportMapProvider.Instance;
 
-        public static readonly OpenStreetMapQuestProvider OpenStreetMapQuest = OpenStreetMapQuestProvider.Instance;
-        public static readonly OpenStreetMapQuestSatelliteProvider OpenStreetMapQuestSatellite = OpenStreetMapQuestSatelliteProvider.Instance;
-        public static readonly OpenStreetMapQuestHybridProvider OpenStreetMapQuestHybrid = OpenStreetMapQuestHybridProvider.Instance;
+      public static readonly OpenStreetMapQuestProvider OpenStreetMapQuest = OpenStreetMapQuestProvider.Instance;
+      public static readonly OpenStreetMapQuestSatelliteProvider OpenStreetMapQuestSatellite = OpenStreetMapQuestSatelliteProvider.Instance;
+      public static readonly OpenStreetMapQuestHybridProvider OpenStreetMapQuestHybrid = OpenStreetMapQuestHybridProvider.Instance;
 
-        public static readonly OpenSeaMapHybridProvider OpenSeaMapHybrid = OpenSeaMapHybridProvider.Instance;
+      public static readonly OpenSeaMapHybridProvider OpenSeaMapHybrid = OpenSeaMapHybridProvider.Instance;
 
 #if OpenStreetOsm
       public static readonly OpenStreetOsmProvider OpenStreetOsm = OpenStreetOsmProvider.Instance;
@@ -75,678 +75,681 @@ namespace GMap.NET.MapProviders
       public static readonly OpenStreetMapSurferProvider OpenStreetMapSurfer = OpenStreetMapSurferProvider.Instance;
       public static readonly OpenStreetMapSurferTerrainProvider OpenStreetMapSurferTerrain = OpenStreetMapSurferTerrainProvider.Instance;
 #endif
-        public static readonly WikiMapiaMapProvider WikiMapiaMap = WikiMapiaMapProvider.Instance;
+      public static readonly WikiMapiaMapProvider WikiMapiaMap = WikiMapiaMapProvider.Instance;
 
-        public static readonly BingMapProvider BingMap = BingMapProvider.Instance;
-        public static readonly BingSatelliteMapProvider BingSatelliteMap = BingSatelliteMapProvider.Instance;
-        public static readonly BingHybridMapProvider BingHybridMap = BingHybridMapProvider.Instance;
-        public static readonly BingOSMapProvider BingOSMap = BingOSMapProvider.Instance;
+      public static readonly BingMapProvider BingMap = BingMapProvider.Instance;
+      public static readonly BingSatelliteMapProvider BingSatelliteMap = BingSatelliteMapProvider.Instance;
+      public static readonly BingHybridMapProvider BingHybridMap = BingHybridMapProvider.Instance;
+      public static readonly BingOSMapProvider BingOSMap = BingOSMapProvider.Instance;
 
-        public static readonly YahooMapProvider YahooMap = YahooMapProvider.Instance;
-        public static readonly YahooSatelliteMapProvider YahooSatelliteMap = YahooSatelliteMapProvider.Instance;
-        public static readonly YahooHybridMapProvider YahooHybridMap = YahooHybridMapProvider.Instance;
+      public static readonly YahooMapProvider YahooMap = YahooMapProvider.Instance;
+      public static readonly YahooSatelliteMapProvider YahooSatelliteMap = YahooSatelliteMapProvider.Instance;
+      public static readonly YahooHybridMapProvider YahooHybridMap = YahooHybridMapProvider.Instance;
 
-        public static readonly GoogleMapProvider GoogleMap = GoogleMapProvider.Instance;
-        public static readonly GoogleSatelliteMapProvider GoogleSatelliteMap = GoogleSatelliteMapProvider.Instance;
-        public static readonly GoogleHybridMapProvider GoogleHybridMap = GoogleHybridMapProvider.Instance;
-        public static readonly GoogleTerrainMapProvider GoogleTerrainMap = GoogleTerrainMapProvider.Instance;
+      public static readonly GoogleMapProvider GoogleMap = GoogleMapProvider.Instance;
+      public static readonly GoogleSatelliteMapProvider GoogleSatelliteMap = GoogleSatelliteMapProvider.Instance;
+      public static readonly GoogleHybridMapProvider GoogleHybridMap = GoogleHybridMapProvider.Instance;
+      public static readonly GoogleTerrainMapProvider GoogleTerrainMap = GoogleTerrainMapProvider.Instance;
 
-        public static readonly GoogleChinaMapProvider GoogleChinaMap = GoogleChinaMapProvider.Instance;
-        public static readonly GoogleChinaSatelliteMapProvider GoogleChinaSatelliteMap = GoogleChinaSatelliteMapProvider.Instance;
-        public static readonly GoogleChinaHybridMapProvider GoogleChinaHybridMap = GoogleChinaHybridMapProvider.Instance;
-        public static readonly GoogleChinaTerrainMapProvider GoogleChinaTerrainMap = GoogleChinaTerrainMapProvider.Instance;
+      public static readonly GoogleChinaMapProvider GoogleChinaMap = GoogleChinaMapProvider.Instance;
+      public static readonly GoogleChinaSatelliteMapProvider GoogleChinaSatelliteMap = GoogleChinaSatelliteMapProvider.Instance;
+      public static readonly GoogleChinaHybridMapProvider GoogleChinaHybridMap = GoogleChinaHybridMapProvider.Instance;
+      public static readonly GoogleChinaTerrainMapProvider GoogleChinaTerrainMap = GoogleChinaTerrainMapProvider.Instance;
 
-        public static readonly GoogleKoreaMapProvider GoogleKoreaMap = GoogleKoreaMapProvider.Instance;
-        public static readonly GoogleKoreaSatelliteMapProvider GoogleKoreaSatelliteMap = GoogleKoreaSatelliteMapProvider.Instance;
-        public static readonly GoogleKoreaHybridMapProvider GoogleKoreaHybridMap = GoogleKoreaHybridMapProvider.Instance;
+      public static readonly GoogleKoreaMapProvider GoogleKoreaMap = GoogleKoreaMapProvider.Instance;
+      public static readonly GoogleKoreaSatelliteMapProvider GoogleKoreaSatelliteMap = GoogleKoreaSatelliteMapProvider.Instance;
+      public static readonly GoogleKoreaHybridMapProvider GoogleKoreaHybridMap = GoogleKoreaHybridMapProvider.Instance;
 
-        public static readonly NearMapProvider NearMap = NearMapProvider.Instance;
-        public static readonly NearSatelliteMapProvider NearSatelliteMap = NearSatelliteMapProvider.Instance;
-        public static readonly NearHybridMapProvider NearHybridMap = NearHybridMapProvider.Instance;
+      public static readonly NearMapProvider NearMap = NearMapProvider.Instance;
+      public static readonly NearSatelliteMapProvider NearSatelliteMap = NearSatelliteMapProvider.Instance;
+      public static readonly NearHybridMapProvider NearHybridMap = NearHybridMapProvider.Instance;
 
-        public static readonly HereMapProvider HereMap = HereMapProvider.Instance;
-        public static readonly HereSatelliteMapProvider HereSatelliteMap = HereSatelliteMapProvider.Instance;
-        public static readonly HereHybridMapProvider HereHybridMap = HereHybridMapProvider.Instance;
-        public static readonly HereTerrainMapProvider HereTerrainMap = HereTerrainMapProvider.Instance;
+      public static readonly HereMapProvider HereMap = HereMapProvider.Instance;
+      public static readonly HereSatelliteMapProvider HereSatelliteMap = HereSatelliteMapProvider.Instance;
+      public static readonly HereHybridMapProvider HereHybridMap = HereHybridMapProvider.Instance;
+      public static readonly HereTerrainMapProvider HereTerrainMap = HereTerrainMapProvider.Instance;
 
-        public static readonly YandexMapProvider YandexMap = YandexMapProvider.Instance;
-        public static readonly YandexSatelliteMapProvider YandexSatelliteMap = YandexSatelliteMapProvider.Instance;
-        public static readonly YandexHybridMapProvider YandexHybridMap = YandexHybridMapProvider.Instance;
+      public static readonly YandexMapProvider YandexMap = YandexMapProvider.Instance;
+      public static readonly YandexSatelliteMapProvider YandexSatelliteMap = YandexSatelliteMapProvider.Instance;
+      public static readonly YandexHybridMapProvider YandexHybridMap = YandexHybridMapProvider.Instance;
 
-        public static readonly LithuaniaMapProvider LithuaniaMap = LithuaniaMapProvider.Instance;
-        public static readonly LithuaniaReliefMapProvider LithuaniaReliefMap = LithuaniaReliefMapProvider.Instance;
-        public static readonly Lithuania3dMapProvider Lithuania3dMap = Lithuania3dMapProvider.Instance;
-        public static readonly LithuaniaOrtoFotoMapProvider LithuaniaOrtoFotoMap = LithuaniaOrtoFotoMapProvider.Instance;
-        public static readonly LithuaniaOrtoFotoOldMapProvider LithuaniaOrtoFotoOldMap = LithuaniaOrtoFotoOldMapProvider.Instance;
-        public static readonly LithuaniaHybridMapProvider LithuaniaHybridMap = LithuaniaHybridMapProvider.Instance;
-        public static readonly LithuaniaHybridOldMapProvider LithuaniaHybridOldMap = LithuaniaHybridOldMapProvider.Instance;
-        public static readonly LithuaniaTOP50 LithuaniaTOP50Map = LithuaniaTOP50.Instance;
+      public static readonly LithuaniaMapProvider LithuaniaMap = LithuaniaMapProvider.Instance;
+      public static readonly LithuaniaReliefMapProvider LithuaniaReliefMap = LithuaniaReliefMapProvider.Instance;
+      public static readonly Lithuania3dMapProvider Lithuania3dMap = Lithuania3dMapProvider.Instance;
+      public static readonly LithuaniaOrtoFotoMapProvider LithuaniaOrtoFotoMap = LithuaniaOrtoFotoMapProvider.Instance;
+      public static readonly LithuaniaOrtoFotoOldMapProvider LithuaniaOrtoFotoOldMap = LithuaniaOrtoFotoOldMapProvider.Instance;
+      public static readonly LithuaniaHybridMapProvider LithuaniaHybridMap = LithuaniaHybridMapProvider.Instance;
+      public static readonly LithuaniaHybridOldMapProvider LithuaniaHybridOldMap = LithuaniaHybridOldMapProvider.Instance;
+      public static readonly LithuaniaTOP50 LithuaniaTOP50Map = LithuaniaTOP50.Instance;
 
-        public static readonly LatviaMapProvider LatviaMap = LatviaMapProvider.Instance;
+      public static readonly LatviaMapProvider LatviaMap = LatviaMapProvider.Instance;
 
-        public static readonly MapBenderWMSProvider MapBenderWMSdemoMap = MapBenderWMSProvider.Instance;
+      public static readonly MapBenderWMSProvider MapBenderWMSdemoMap = MapBenderWMSProvider.Instance;
 
-        public static readonly TurkeyMapProvider TurkeyMap = TurkeyMapProvider.Instance;
+      public static readonly TurkeyMapProvider TurkeyMap = TurkeyMapProvider.Instance;
 
-        public static readonly CloudMadeMapProvider CloudMadeMap = CloudMadeMapProvider.Instance;
+      public static readonly CloudMadeMapProvider CloudMadeMap = CloudMadeMapProvider.Instance;
 
-        public static readonly SpainMapProvider SpainMap = SpainMapProvider.Instance;
+      public static readonly SpainMapProvider SpainMap = SpainMapProvider.Instance;
 
-        public static readonly CzechMapProviderOld CzechOldMap = CzechMapProviderOld.Instance;
-        public static readonly CzechSatelliteMapProviderOld CzechSatelliteOldMap = CzechSatelliteMapProviderOld.Instance;
-        public static readonly CzechHybridMapProviderOld CzechHybridOldMap = CzechHybridMapProviderOld.Instance;
-        public static readonly CzechTuristMapProviderOld CzechTuristOldMap = CzechTuristMapProviderOld.Instance;
-        public static readonly CzechHistoryMapProviderOld CzechHistoryOldMap = CzechHistoryMapProviderOld.Instance;
+      public static readonly CzechMapProviderOld CzechOldMap = CzechMapProviderOld.Instance;
+      public static readonly CzechSatelliteMapProviderOld CzechSatelliteOldMap = CzechSatelliteMapProviderOld.Instance;
+      public static readonly CzechHybridMapProviderOld CzechHybridOldMap = CzechHybridMapProviderOld.Instance;
+      public static readonly CzechTuristMapProviderOld CzechTuristOldMap = CzechTuristMapProviderOld.Instance;
+      public static readonly CzechHistoryMapProviderOld CzechHistoryOldMap = CzechHistoryMapProviderOld.Instance;
 
-        public static readonly CzechMapProvider CzechMap = CzechMapProvider.Instance;
-        public static readonly CzechSatelliteMapProvider CzechSatelliteMap = CzechSatelliteMapProvider.Instance;
-        public static readonly CzechHybridMapProvider CzechHybridMap = CzechHybridMapProvider.Instance;
-        public static readonly CzechTuristMapProvider CzechTuristMap = CzechTuristMapProvider.Instance;
-        public static readonly CzechTuristWinterMapProvider CzechTuristWinterMap = CzechTuristWinterMapProvider.Instance;
-        public static readonly CzechHistoryMapProvider CzechHistoryMap = CzechHistoryMapProvider.Instance;
-        public static readonly CzechGeographicMapProvider CzechGeographicMap = CzechGeographicMapProvider.Instance;
-        
-        public static readonly ArcGIS_Imagery_World_2D_MapProvider ArcGIS_Imagery_World_2D_Map = ArcGIS_Imagery_World_2D_MapProvider.Instance;
-        public static readonly ArcGIS_ShadedRelief_World_2D_MapProvider ArcGIS_ShadedRelief_World_2D_Map = ArcGIS_ShadedRelief_World_2D_MapProvider.Instance;
-        public static readonly ArcGIS_StreetMap_World_2D_MapProvider ArcGIS_StreetMap_World_2D_Map = ArcGIS_StreetMap_World_2D_MapProvider.Instance;
-        public static readonly ArcGIS_Topo_US_2D_MapProvider ArcGIS_Topo_US_2D_Map = ArcGIS_Topo_US_2D_MapProvider.Instance;
+      public static readonly CzechMapProvider CzechMap = CzechMapProvider.Instance;
+      public static readonly CzechSatelliteMapProvider CzechSatelliteMap = CzechSatelliteMapProvider.Instance;
+      public static readonly CzechHybridMapProvider CzechHybridMap = CzechHybridMapProvider.Instance;
+      public static readonly CzechTuristMapProvider CzechTuristMap = CzechTuristMapProvider.Instance;
+      public static readonly CzechTuristWinterMapProvider CzechTuristWinterMap = CzechTuristWinterMapProvider.Instance;
+      public static readonly CzechHistoryMapProvider CzechHistoryMap = CzechHistoryMapProvider.Instance;
+      public static readonly CzechGeographicMapProvider CzechGeographicMap = CzechGeographicMapProvider.Instance;
 
-        public static readonly ArcGIS_World_Physical_MapProvider ArcGIS_World_Physical_Map = ArcGIS_World_Physical_MapProvider.Instance;
-        public static readonly ArcGIS_World_Shaded_Relief_MapProvider ArcGIS_World_Shaded_Relief_Map = ArcGIS_World_Shaded_Relief_MapProvider.Instance;
-        public static readonly ArcGIS_World_Street_MapProvider ArcGIS_World_Street_Map = ArcGIS_World_Street_MapProvider.Instance;
-        public static readonly ArcGIS_World_Terrain_Base_MapProvider ArcGIS_World_Terrain_Base_Map = ArcGIS_World_Terrain_Base_MapProvider.Instance;
-        public static readonly ArcGIS_World_Topo_MapProvider ArcGIS_World_Topo_Map = ArcGIS_World_Topo_MapProvider.Instance;
+      public static readonly ArcGIS_Imagery_World_2D_MapProvider ArcGIS_Imagery_World_2D_Map = ArcGIS_Imagery_World_2D_MapProvider.Instance;
+      public static readonly ArcGIS_ShadedRelief_World_2D_MapProvider ArcGIS_ShadedRelief_World_2D_Map = ArcGIS_ShadedRelief_World_2D_MapProvider.Instance;
+      public static readonly ArcGIS_StreetMap_World_2D_MapProvider ArcGIS_StreetMap_World_2D_Map = ArcGIS_StreetMap_World_2D_MapProvider.Instance;
+      public static readonly ArcGIS_Topo_US_2D_MapProvider ArcGIS_Topo_US_2D_Map = ArcGIS_Topo_US_2D_MapProvider.Instance;
 
-        public static readonly ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_MapProvider ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_Map = ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_MapProvider.Instance;
+      public static readonly ArcGIS_World_Physical_MapProvider ArcGIS_World_Physical_Map = ArcGIS_World_Physical_MapProvider.Instance;
+      public static readonly ArcGIS_World_Shaded_Relief_MapProvider ArcGIS_World_Shaded_Relief_Map = ArcGIS_World_Shaded_Relief_MapProvider.Instance;
+      public static readonly ArcGIS_World_Street_MapProvider ArcGIS_World_Street_Map = ArcGIS_World_Street_MapProvider.Instance;
+      public static readonly ArcGIS_World_Terrain_Base_MapProvider ArcGIS_World_Terrain_Base_Map = ArcGIS_World_Terrain_Base_MapProvider.Instance;
+      public static readonly ArcGIS_World_Topo_MapProvider ArcGIS_World_Topo_Map = ArcGIS_World_Topo_MapProvider.Instance;
 
-        public static readonly SwedenMapProvider SwedenMap = SwedenMapProvider.Instance;
-        public static readonly UMPMapProvider UMPMap = UMPMapProvider.Instance;
+      public static readonly ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_MapProvider ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_Map = ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_MapProvider.Instance;
 
-        public static readonly CustomMapProvider CustomMap = CustomMapProvider.Instance;
+      public static readonly SwedenMapProvider SwedenMap = SwedenMapProvider.Instance;
+      public static readonly UMPMapProvider UMPMap = UMPMapProvider.Instance;
 
-        static List<GMapProvider> list;
+      public static readonly CustomMapProvider CustomMap = CustomMapProvider.Instance;
 
-        /// <summary>
-        /// get all instances of the supported providers
-        /// </summary>
-        public static List<GMapProvider> List
-        {
-            get
-            {
-                return list;
-            }
-        }
+      static List<GMapProvider> list;
 
-        static Dictionary<Guid, GMapProvider> Hash;
+      /// <summary>
+      /// get all instances of the supported providers
+      /// </summary>
+      public static List<GMapProvider> List
+      {
+         get
+         {
+            return list;
+         }
+      }
 
-        public static GMapProvider TryGetProvider(Guid id)
-        {
-            GMapProvider ret;
+      static Dictionary<Guid, GMapProvider> Hash;
 
-            if (Hash.TryGetValue(id, out ret))
-            {
-                return ret;
-            }
+      public static GMapProvider TryGetProvider(Guid id)
+      {
+         GMapProvider ret;
 
+         if (Hash.TryGetValue(id, out ret))
+         {
+            return ret;
+         }
+
+         return null;
+      }
+
+      static Dictionary<int, GMapProvider> DbHash;
+
+      public static GMapProvider TryGetProvider(int DbId)
+      {
+         GMapProvider ret;
+
+         if (DbHash.TryGetValue(DbId, out ret))
+         {
+            return ret;
+         }
+
+         return null;
+      }
+
+      public static GMapProvider TryGetProvider(string ProviderName)
+      {
+         if (list.Exists(x => x.Name == ProviderName))
+         {
+            return list.Find(x => x.Name == ProviderName);
+         }
+         else
+         {
             return null;
-        }
+         }
+      }
+   }
 
-        static Dictionary<int, GMapProvider> DbHash;
+   /// <summary>
+   /// base class for each map provider
+   /// </summary>
+   public abstract class GMapProvider
+   {
+      /// <summary>
+      /// unique provider id
+      /// </summary>
+      public abstract Guid Id
+      {
+         get;
+      }
 
-        public static GMapProvider TryGetProvider(int DbId)
-        {
-            GMapProvider ret;
+      /// <summary>
+      /// provider name
+      /// </summary>
+      public abstract string Name
+      {
+         get;
+      }
 
-            if (DbHash.TryGetValue(DbId, out ret))
-            {
-                return ret;
-            }
+      /// <summary>
+      /// provider projection
+      /// </summary>
+      public abstract PureProjection Projection
+      {
+         get;
+      }
 
-            return null;
-        }
+      /// <summary>
+      /// provider overlays
+      /// </summary>
+      public abstract GMapProvider[] Overlays
+      {
+         get;
+      }
 
-        public static GMapProvider TryGetProvider(string ProviderName)
-        {
-            if (list.Exists(x => x.Name == ProviderName))
-            {
-                return list.Find(x => x.Name == ProviderName);
-            }
-            else
-            {
-                return null;
-            }
-        }
-    }
+      /// <summary>
+      /// gets tile image using implmented provider
+      /// </summary>
+      /// <param name="pos"></param>
+      /// <param name="zoom"></param>
+      /// <returns></returns>
+      public abstract PureImage GetTileImage(GPoint pos, int zoom);
 
-    /// <summary>
-    /// base class for each map provider
-    /// </summary>
-    public abstract class GMapProvider
-    {
-        /// <summary>
-        /// unique provider id
-        /// </summary>
-        public abstract Guid Id
-        {
-            get;
-        }
+      static readonly List<GMapProvider> MapProviders = new List<GMapProvider>();
 
-        /// <summary>
-        /// provider name
-        /// </summary>
-        public abstract string Name
-        {
-            get;
-        }
+      protected GMapProvider()
+      {
+         using (var HashProvider = new SHA1CryptoServiceProvider())
+         {
+            DbId = Math.Abs(BitConverter.ToInt32(HashProvider.ComputeHash(Id.ToByteArray()), 0));
+         }
 
-        /// <summary>
-        /// provider projection
-        /// </summary>
-        public abstract PureProjection Projection
-        {
-            get;
-        }
+         if (MapProviders.Exists(p => p.Id == Id || p.DbId == DbId))
+         {
+            throw new Exception("such provider id already exsists, try regenerate your provider guid...");
+         }
 
-        /// <summary>
-        /// provider overlays
-        /// </summary>
-        public abstract GMapProvider[] Overlays
-        {
-            get;
-        }
+         MapProviders.Add(this);
+      }
 
-        /// <summary>
-        /// gets tile image using implmented provider
-        /// </summary>
-        /// <param name="pos"></param>
-        /// <param name="zoom"></param>
-        /// <returns></returns>
-        public abstract PureImage GetTileImage(GPoint pos, int zoom);
+      static GMapProvider()
+      {
+         WebProxy = EmptyWebProxy.Instance;
+      }
 
-        static readonly List<GMapProvider> MapProviders = new List<GMapProvider>();
+      bool isInitialized = false;
 
-        protected GMapProvider()
-        {
-            using (var HashProvider = new SHA1CryptoServiceProvider())
-            {
-                DbId = Math.Abs(BitConverter.ToInt32(HashProvider.ComputeHash(Id.ToByteArray()), 0));
-            }
+      /// <summary>
+      /// was provider initialized
+      /// </summary>
+      public bool IsInitialized
+      {
+         get
+         {
+            return isInitialized;
+         }
+         internal set
+         {
+            isInitialized = value;
+         }
+      }
 
-            if (MapProviders.Exists(p => p.Id == Id || p.DbId == DbId))
-            {
-                throw new Exception("such provider id already exsists, try regenerate your provider guid...");
-            }
+      /// <summary>
+      /// called before first use
+      /// </summary>
+      public virtual void OnInitialized()
+      {
+         // nice place to detect current provider version
+      }
 
-            MapProviders.Add(this);
-        }
+      /// <summary>
+      /// id for database, a hash of provider guid
+      /// </summary>
+      public readonly int DbId;
 
-        static GMapProvider()
-        {
-            WebProxy = EmptyWebProxy.Instance;
-        }
+      /// <summary>
+      /// area of map
+      /// </summary>
+      public RectLatLng? Area;
 
-        bool isInitialized = false;
+      /// <summary>
+      /// minimum level of zoom
+      /// </summary>
+      public int MinZoom;
 
-        /// <summary>
-        /// was provider initialized
-        /// </summary>
-        public bool IsInitialized
-        {
-            get
-            {
-                return isInitialized;
-            }
-            internal set
-            {
-                isInitialized = value;
-            }
-        }
+      /// <summary>
+      /// maximum level of zoom
+      /// </summary>
+      public int? MaxZoom = 17;
 
-        /// <summary>
-        /// called before first use
-        /// </summary>
-        public virtual void OnInitialized()
-        {
-            // nice place to detect current provider version
-        }
+      /// <summary>
+      /// proxy for net access
+      /// </summary>
+      public static IWebProxy WebProxy;
 
-        /// <summary>
-        /// id for database, a hash of provider guid
-        /// </summary>
-        public readonly int DbId;
+      /// <summary>
+      /// Connect trough a SOCKS 4/5 proxy server
+      /// </summary>
+      public static bool IsSocksProxy = false;
 
-        /// <summary>
-        /// area of map
-        /// </summary>
-        public RectLatLng? Area;
+      /// <summary>
+      /// NetworkCredential for tile http access
+      /// </summary>
+      public static ICredentials Credential;
 
-        /// <summary>
-        /// minimum level of zoom
-        /// </summary>
-        public int MinZoom;
+      /// <summary>
+      /// Gets or sets the value of the User-agent HTTP header.
+      /// It's pseudo-randomized to avoid blockages...
+      /// </summary>                                
+      public static string UserAgent = string.Format("Mozilla/5.0 (Windows NT {1}.0; {2}rv:{0}.0) Gecko/20100101 Firefox/{0}.0",
+         Stuff.random.Next(DateTime.Today.Year - 1969 - 5, DateTime.Today.Year - 1969),
+         Stuff.random.Next(0, 10) % 2 == 0 ? 10 : 6,
+         Stuff.random.Next(0, 10) % 2 == 1 ? string.Empty : "WOW64; ");
 
-        /// <summary>
-        /// maximum level of zoom
-        /// </summary>
-        public int? MaxZoom = 17;
-
-        /// <summary>
-        /// proxy for net access
-        /// </summary>
-        public static IWebProxy WebProxy;
-
-        /// <summary>
-        /// Connect trough a SOCKS 4/5 proxy server
-        /// </summary>
-        public static bool IsSocksProxy = false;
-
-        /// <summary>
-        /// NetworkCredential for tile http access
-        /// </summary>
-        public static ICredentials Credential;
-
-        /// <summary>
-        /// Gets or sets the value of the User-agent HTTP header.
-        /// It's pseudo-randomized to avoid blockages...
-        /// </summary>                                
-        public static string UserAgent = string.Format("Mozilla/5.0 (Windows NT {1}.0; {2}rv:{0}.0) Gecko/20100101 Firefox/{0}.0",
-            Stuff.random.Next(DateTime.Today.Year - 1969 - 5, DateTime.Today.Year - 1969),
-            Stuff.random.Next(0, 10) % 2 == 0 ? 10 : 6,
-            Stuff.random.Next(0, 10) % 2 == 1 ? string.Empty : "WOW64; ");         
-
-        /// <summary>
-        /// timeout for provider connections
-        /// </summary>
+      /// <summary>
+      /// timeout for provider connections
+      /// </summary>
 #if !PocketPC
-        public static int TimeoutMs = 5 * 1000;
+      public static int TimeoutMs = 5 * 1000;
 #else
       public static int TimeoutMs = 44 * 1000;
 #endif
-        /// <summary>
-        /// Time to live of cache, in hours. Default: 240 (10 days).
-        /// </summary>
-        public static int TTLCache = 240;
+      /// <summary>
+      /// Time to live of cache, in hours. Default: 240 (10 days).
+      /// </summary>
+      public static int TTLCache = 240;
 
-        /// <summary>
-        /// Gets or sets the value of the Referer HTTP header.
-        /// </summary>
-        public string RefererUrl = string.Empty;
+      /// <summary>
+      /// Gets or sets the value of the Referer HTTP header.
+      /// </summary>
+      public string RefererUrl = string.Empty;
 
-        public string Copyright = string.Empty;
+      public string Copyright = string.Empty;
 
-        /// <summary>
-        /// true if tile origin at BottomLeft, WMS-C
-        /// </summary>
-        public bool InvertedAxisY = false;
+      /// <summary>
+      /// true if tile origin at BottomLeft, WMS-C
+      /// </summary>
+      public bool InvertedAxisY = false;
 
-        static string languageStr = "en";
-        public static string LanguageStr
-        {
-            get
-            {
-                return languageStr;
-            }
-        }
-        static LanguageType language = LanguageType.English;
+      static string languageStr = "en";
+      public static string LanguageStr
+      {
+         get
+         {
+            return languageStr;
+         }
+      }
+      static LanguageType language = LanguageType.English;
 
-        /// <summary>
-        /// map language
-        /// </summary>
-        public static LanguageType Language
-        {
-            get
-            {
-                return language;
-            }
-            set
-            {
-                language = value;
-                languageStr = Stuff.EnumToString(Language);
-            }
-        }
+      /// <summary>
+      /// map language
+      /// </summary>
+      public static LanguageType Language
+      {
+         get
+         {
+            return language;
+         }
+         set
+         {
+            language = value;
+            languageStr = Stuff.EnumToString(Language);
+         }
+      }
 
-        /// <summary>
-        /// to bypass the cache, set to true
-        /// </summary>
-        public bool BypassCache = false;
+      /// <summary>
+      /// to bypass the cache, set to true
+      /// </summary>
+      public bool BypassCache = false;
 
-        /// <summary>
-        /// internal proxy for image managment
-        /// </summary>
-        internal static PureImageProxy TileImageProxy;
+      /// <summary>
+      /// internal proxy for image management
+      /// </summary>
+      internal static PureImageProxy TileImageProxy = DefaultImageProxy.Instance;
 
-        static readonly string requestAccept = "*/*";
-        static readonly string responseContentType = "image";
+      static readonly string requestAccept = "*/*";
+      static readonly string responseContentType = "image";
 
-        protected virtual bool CheckTileImageHttpResponse(WebResponse response)
-        {
-            //Debug.WriteLine(response.StatusCode + "/" + response.StatusDescription + "/" + response.ContentType + " -> " + response.ResponseUri);
-            return response.ContentType.Contains(responseContentType);
-        }
-        
-        string Authorization = string.Empty;
-        
-        /// <summary>
-        /// http://blog.kowalczyk.info/article/at3/Forcing-basic-http-authentication-for-HttpWebReq.html
-        /// </summary>
-        /// <param name="userName"></param>
-        /// <param name="userPassword"></param>
-        public void ForceBasicHttpAuthentication(string userName, string userPassword)
-        {
-            Authorization = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(userName + ":" + userPassword));
-        }
+      protected virtual bool CheckTileImageHttpResponse(WebResponse response)
+      {
+         //Debug.WriteLine(response.StatusCode + "/" + response.StatusDescription + "/" + response.ContentType + " -> " + response.ResponseUri);
+         return response.ContentType.Contains(responseContentType);
+      }
 
-        protected PureImage GetTileImageUsingHttp(string url)
-        {
-            PureImage ret = null;
+      string Authorization = string.Empty;
+
+      /// <summary>
+      /// http://blog.kowalczyk.info/article/at3/Forcing-basic-http-authentication-for-HttpWebReq.html
+      /// </summary>
+      /// <param name="userName"></param>
+      /// <param name="userPassword"></param>
+      public void ForceBasicHttpAuthentication(string userName, string userPassword)
+      {
+         Authorization = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(userName + ":" + userPassword));
+      }
+
+      protected PureImage GetTileImageUsingHttp(string url)
+      {
+         PureImage ret = null;
 
 #if !PocketPC
-            WebRequest request = IsSocksProxy ? SocksHttpWebRequest.Create(url) : WebRequest.Create(url);
+         WebRequest request = IsSocksProxy ? SocksHttpWebRequest.Create(url) : WebRequest.Create(url);
 #else
             WebRequest request = WebRequest.Create(url);
 #endif
-            if (WebProxy != null)
-            {
-                request.Proxy = WebProxy;
-            }
+         if (WebProxy != null)
+         {
+            request.Proxy = WebProxy;
+         }
 
-            if (Credential != null)
-            {
-                request.PreAuthenticate = true;
-                request.Credentials = Credential;
-            }
-            
-            if(!string.IsNullOrEmpty(Authorization))
-            {
-                request.Headers.Set("Authorization", Authorization);
-            }
-            
-            if (request is HttpWebRequest)
-            {
-                var r = request as HttpWebRequest;
-                r.UserAgent = UserAgent;
-                r.ReadWriteTimeout = TimeoutMs * 6;
-                r.Accept = requestAccept;
-                r.Referer = RefererUrl;
-                r.Timeout = TimeoutMs;
-            }
+         if (Credential != null)
+         {
+            request.PreAuthenticate = true;
+            request.Credentials = Credential;
+         }
+
+         if (!string.IsNullOrEmpty(Authorization))
+         {
+            request.Headers.Set("Authorization", Authorization);
+         }
+
+         if (request is HttpWebRequest)
+         {
+            var r = request as HttpWebRequest;
+            r.UserAgent = UserAgent;
+            r.ReadWriteTimeout = TimeoutMs * 6;
+            r.Accept = requestAccept;
+            r.Referer = RefererUrl;
+            r.Timeout = TimeoutMs;
+         }
 #if !PocketPC
-            else if (request is SocksHttpWebRequest)
+         else if (request is SocksHttpWebRequest)
+         {
+            var r = request as SocksHttpWebRequest;
+
+            if (!string.IsNullOrEmpty(UserAgent))
             {
-                var r = request as SocksHttpWebRequest;
-
-                if (!string.IsNullOrEmpty(UserAgent))
-                {
-                    r.Headers.Add("User-Agent", UserAgent);
-                }
-
-                if (!string.IsNullOrEmpty(requestAccept))
-                {
-                    r.Headers.Add("Accept", requestAccept);
-                }
-
-                if (!string.IsNullOrEmpty(RefererUrl))
-                {
-                    r.Headers.Add("Referer", RefererUrl);
-                }              
+               r.Headers.Add("User-Agent", UserAgent);
             }
-#endif       
-            using (var response = request.GetResponse())
+
+            if (!string.IsNullOrEmpty(requestAccept))
             {
-                if (CheckTileImageHttpResponse(response))
-                {
-                    using (Stream responseStream = response.GetResponseStream())
-                    {
-                        MemoryStream data = Stuff.CopyStream(responseStream, false);
+               r.Headers.Add("Accept", requestAccept);
+            }
 
-                        Debug.WriteLine("Response[" + data.Length + " bytes]: " + url);
+            if (!string.IsNullOrEmpty(RefererUrl))
+            {
+               r.Headers.Add("Referer", RefererUrl);
+            }
+         }
+#endif
+         using (var response = request.GetResponse())
+         {
+            if (CheckTileImageHttpResponse(response))
+            {
+               using (var responseStream = response.GetResponseStream())
+               {
+                  var data = Stuff.CopyStream(responseStream, false);
 
-                        if (data.Length > 0)
-                        {
-                            ret = TileImageProxy.FromStream(data);
+                  Debug.WriteLine("Response[" + data.Length + " bytes]: " + url);
 
-                            if (ret != null)
-                            {
-                                ret.Data = data;
-                                ret.Data.Position = 0;
-                            }
-                            else
-                            {
-                                data.Dispose();
-                            }
-                        }
-                        data = null;
-                    }
-                }
-                else
-                {
-                    Debug.WriteLine("CheckTileImageHttpResponse[false]: " + url);
-                }
+                  if (data.Length > 0)
+                  {
+                     ret = TileImageProxy.FromStream(data);
+
+                     if (ret != null)
+                     {
+                        ret.Data = data;
+                        ret.Data.Position = 0;
+                     }
+                     else
+                     {
+                        data.Dispose();
+                     }
+                  }
+
+                  data = null;
+               }
+            }
+            else
+            {
+               Debug.WriteLine("CheckTileImageHttpResponse[false]: " + url);
+            }
 #if PocketPC
                 request.Abort();
 #endif
-                response.Close();
-            }
-            return ret;
-        }
+            response.Close();
+         }
 
-        protected string GetContentUsingHttp(string url)
-        {
-            string ret = string.Empty;
+         return ret;
+      }
+
+      protected string GetContentUsingHttp(string url)
+      {
+         string ret = string.Empty;
 
 #if !PocketPC
-            WebRequest request = IsSocksProxy ? SocksHttpWebRequest.Create(url) : WebRequest.Create(url);
+         WebRequest request = IsSocksProxy ? SocksHttpWebRequest.Create(url) : WebRequest.Create(url);
 #else
             WebRequest request = WebRequest.Create(url);
 #endif
 
-            if (WebProxy != null)
-            {
-                request.Proxy = WebProxy;
-            }
+         if (WebProxy != null)
+         {
+            request.Proxy = WebProxy;
+         }
 
-            if (Credential != null)
-            {
-                request.PreAuthenticate = true;
-                request.Credentials = Credential;
-            }
-            
+         if (Credential != null)
+         {
+            request.PreAuthenticate = true;
+            request.Credentials = Credential;
+         }
 
-            if (!string.IsNullOrEmpty(Authorization))
-            {
-                request.Headers.Set("Authorization", Authorization);
-            }
 
-            if (request is HttpWebRequest)
-            {
-                var r = request as HttpWebRequest;
-                r.UserAgent = UserAgent;
-                r.ReadWriteTimeout = TimeoutMs * 6;
-                r.Accept = requestAccept;
-                r.Referer = RefererUrl;
-                r.Timeout = TimeoutMs;               
-            }
+         if (!string.IsNullOrEmpty(Authorization))
+         {
+            request.Headers.Set("Authorization", Authorization);
+         }
+
+         if (request is HttpWebRequest)
+         {
+            var r = request as HttpWebRequest;
+            r.UserAgent = UserAgent;
+            r.ReadWriteTimeout = TimeoutMs * 6;
+            r.Accept = requestAccept;
+            r.Referer = RefererUrl;
+            r.Timeout = TimeoutMs;
+         }
 #if !PocketPC
-            else if (request is SocksHttpWebRequest)
+         else if (request is SocksHttpWebRequest)
+         {
+            var r = request as SocksHttpWebRequest;
+
+            if (!string.IsNullOrEmpty(UserAgent))
             {
-                var r = request as SocksHttpWebRequest;
-
-                if (!string.IsNullOrEmpty(UserAgent))
-                {
-                    r.Headers.Add("User-Agent", UserAgent);
-                }
-
-                if (!string.IsNullOrEmpty(requestAccept))
-                {
-                    r.Headers.Add("Accept", requestAccept);
-                }
-
-                if (!string.IsNullOrEmpty(RefererUrl))
-                {
-                    r.Headers.Add("Referer", RefererUrl);
-                }
+               r.Headers.Add("User-Agent", UserAgent);
             }
+
+            if (!string.IsNullOrEmpty(requestAccept))
+            {
+               r.Headers.Add("Accept", requestAccept);
+            }
+
+            if (!string.IsNullOrEmpty(RefererUrl))
+            {
+               r.Headers.Add("Referer", RefererUrl);
+            }
+         }
 #endif
-            WebResponse response = null;
+         WebResponse response = null;
 
-            try
-            {
-                response = request.GetResponse();
-            }
-            catch (WebException ex)
-            {
-                response = (HttpWebResponse)ex.Response;
-            }
-            catch (Exception)
-            {
-                response = null;
-            }
+         try
+         {
+            response = request.GetResponse();
+         }
+         catch (WebException ex)
+         {
+            response = (HttpWebResponse)ex.Response;
+         }
+         catch (Exception)
+         {
+            response = null;
+         }
 
-            if (response != null)
+         if (response != null)
+         {
+            using (Stream responseStream = response.GetResponseStream())
             {
-                using (Stream responseStream = response.GetResponseStream())
-                {
-                    using (StreamReader read = new StreamReader(responseStream, Encoding.UTF8))
-                    {
-                        ret = read.ReadToEnd();
-                    }
-                }
+               using (StreamReader read = new StreamReader(responseStream, Encoding.UTF8))
+               {
+                  ret = read.ReadToEnd();
+               }
+            }
 #if PocketPC
                 request.Abort();
 #endif
-                response.Close();
-            }
+            response.Close();
+         }
 
-            return ret;
-        }
+         return ret;
+      }
 
 #if !PocketPC
-        /// <summary>
-        /// use at your own risk, storing tiles in files is slow and hard on the file system
-        /// </summary>
-        /// <param name="fileName"></param>
-        /// <returns></returns>
-        protected virtual PureImage GetTileImageFromFile(string fileName)
-        {
-            return GetTileImageFromArray(File.ReadAllBytes(fileName));
-        }
+      /// <summary>
+      /// use at your own risk, storing tiles in files is slow and hard on the file system
+      /// </summary>
+      /// <param name="fileName"></param>
+      /// <returns></returns>
+      protected virtual PureImage GetTileImageFromFile(string fileName)
+      {
+         return GetTileImageFromArray(File.ReadAllBytes(fileName));
+      }
 #endif
-        protected virtual PureImage GetTileImageFromArray(byte [] data)
-        {
-            return TileImageProxy.FromArray(data);
-        }
-        
-        protected static int GetServerNum(GPoint pos, int max)
-        {
-            return (int)(pos.X + 2 * pos.Y) % max;
-        }
+      protected virtual PureImage GetTileImageFromArray(byte[] data)
+      {
+         return TileImageProxy.FromArray(data);
+      }
 
-        public override int GetHashCode()
-        {
-            return (int)DbId;
-        }
+      protected static int GetServerNum(GPoint pos, int max)
+      {
+         return (int)(pos.X + 2 * pos.Y) % max;
+      }
 
-        public override bool Equals(object obj)
-        {
-            if (obj is GMapProvider)
-            {
-                return Id.Equals((obj as GMapProvider).Id);
-            }
-            return false;
-        }        
+      public override int GetHashCode()
+      {
+         return (int)DbId;
+      }
 
-        public override string ToString()
-        {
-            return Name;
-        }
-    }
+      public override bool Equals(object obj)
+      {
+         if (obj is GMapProvider)
+         {
+            return Id.Equals((obj as GMapProvider).Id);
+         }
 
-    /// <summary>
-    /// represents empty provider
-    /// </summary>
-    public class EmptyProvider : GMapProvider
-    {
-        public static readonly EmptyProvider Instance;
+         return false;
+      }
 
-        EmptyProvider()
-        {
-            MaxZoom = null;
-        }
+      public override string ToString()
+      {
+         return Name;
+      }
+   }
 
-        static EmptyProvider()
-        {
-            Instance = new EmptyProvider();
-        }
+   /// <summary>
+   /// represents empty provider
+   /// </summary>
+   public class EmptyProvider : GMapProvider
+   {
+      public static readonly EmptyProvider Instance;
 
-        #region GMapProvider Members
+      EmptyProvider()
+      {
+         MaxZoom = null;
+      }
 
-        public override Guid Id
-        {
-            get
-            {
-                return Guid.Empty;
-            }
-        }
+      static EmptyProvider()
+      {
+         Instance = new EmptyProvider();
+      }
 
-        readonly string name = "None";
-        public override string Name
-        {
-            get
-            {
-                return name;
-            }
-        }
+      #region GMapProvider Members
 
-        readonly MercatorProjection projection = MercatorProjection.Instance;
-        public override PureProjection Projection
-        {
-            get
-            {
-                return projection;
-            }
-        }
+      public override Guid Id
+      {
+         get
+         {
+            return Guid.Empty;
+         }
+      }
 
-        public override GMapProvider[] Overlays
-        {
-            get
-            {
-                return null;
-            }
-        }
+      readonly string name = "None";
+      public override string Name
+      {
+         get
+         {
+            return name;
+         }
+      }
 
-        public override PureImage GetTileImage(GPoint pos, int zoom)
-        {
+      readonly MercatorProjection projection = MercatorProjection.Instance;
+      public override PureProjection Projection
+      {
+         get
+         {
+            return projection;
+         }
+      }
+
+      public override GMapProvider[] Overlays
+      {
+         get
+         {
             return null;
-        }
+         }
+      }
 
-        #endregion
-    }
+      public override PureImage GetTileImage(GPoint pos, int zoom)
+      {
+         return null;
+      }
 
-    public sealed class EmptyWebProxy : IWebProxy
-    {
-        public static readonly EmptyWebProxy Instance = new EmptyWebProxy();
+      #endregion
+   }
 
-        private ICredentials m_credentials;
-        public ICredentials Credentials
-        {
-            get
-            {
-                return this.m_credentials;
-            }
-            set
-            {
-                this.m_credentials = value;
-            }
-        }
+   public sealed class EmptyWebProxy : IWebProxy
+   {
+      public static readonly EmptyWebProxy Instance = new EmptyWebProxy();
 
-        public Uri GetProxy(Uri uri)
-        {
-            return uri;
-        }
+      private ICredentials m_credentials;
+      public ICredentials Credentials
+      {
+         get
+         {
+            return this.m_credentials;
+         }
+         set
+         {
+            this.m_credentials = value;
+         }
+      }
 
-        public bool IsBypassed(Uri uri)
-        {
-            return true;
-        }
-    }
+      public Uri GetProxy(Uri uri)
+      {
+         return uri;
+      }
+
+      public bool IsBypassed(Uri uri)
+      {
+         return true;
+      }
+   }
 }

--- a/GMap.NET/GMap.NET.WindowsForms/GMap.NET.WindowsForms/.editorconfig
+++ b/GMap.NET/GMap.NET.WindowsForms/GMap.NET.WindowsForms/.editorconfig
@@ -1,0 +1,124 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+# All files
+[*]
+indent_style = space
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+###############################
+# VB Coding Conventions       #
+###############################
+[*.vb]
+# Modifier preferences
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/GMap.NET/GMap.NET.WindowsForms/GMap.NET.WindowsForms/.editorconfig
+++ b/GMap.NET/GMap.NET.WindowsForms/GMap.NET.WindowsForms/.editorconfig
@@ -8,7 +8,7 @@ root = true
 indent_style = space
 # Code files
 [*.{cs,csx,vb,vbx}]
-indent_size = 4
+indent_size = 3
 insert_final_newline = true
 charset = utf-8-bom
 ###############################

--- a/GMap.NET/GMap.NET.WindowsPresentation/.editorconfig
+++ b/GMap.NET/GMap.NET.WindowsPresentation/.editorconfig
@@ -1,0 +1,124 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+# All files
+[*]
+indent_style = space
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+###############################
+# VB Coding Conventions       #
+###############################
+[*.vb]
+# Modifier preferences
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/GMap.NET/GMap.NET.WindowsPresentation/.editorconfig
+++ b/GMap.NET/GMap.NET.WindowsPresentation/.editorconfig
@@ -8,7 +8,7 @@ root = true
 indent_style = space
 # Code files
 [*.{cs,csx,vb,vbx}]
-indent_size = 4
+indent_size = 3
 insert_final_newline = true
 charset = utf-8-bom
 ###############################

--- a/GMap.NET/GMap.NET.WindowsPresentation/GMap.NET.WindowsPresentation/GMapImage.cs
+++ b/GMap.NET/GMap.NET.WindowsPresentation/GMap.NET.WindowsPresentation/GMapImage.cs
@@ -1,229 +1,229 @@
 ﻿
 namespace GMap.NET.WindowsPresentation
 {
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Diagnostics;
-    using System.IO;
-    using System.Windows;
-    using System.Windows.Controls;
-    using System.Windows.Media;
-    using System.Windows.Media.Imaging;
-    using GMap.NET.Internals;
-    using GMap.NET.MapProviders;
+   using System.Collections.Generic;
+   using System.Collections.ObjectModel;
+   using System.Diagnostics;
+   using System.IO;
+   using System.Windows;
+   using System.Windows.Controls;
+   using System.Windows.Media;
+   using System.Windows.Media.Imaging;
+   using GMap.NET.Internals;
+   using GMap.NET.MapProviders;
 
-    /// <summary>
-    /// image abstraction
-    /// </summary>
-    public class GMapImage : PureImage
-    {
-        public ImageSource Img;
+   /// <summary>
+   /// image abstraction
+   /// </summary>
+   public class GMapImage : PureImage
+   {
+      public ImageSource Img;
 
-        public override void Dispose()
-        {
-            if (Img != null)
+      public override void Dispose()
+      {
+         if (Img != null)
+         {
+            Img = null;
+         }
+
+         if (Data != null)
+         {
+            Data.Dispose();
+            Data = null;
+         }
+      }
+   }
+
+   /// <summary>
+   /// image abstraction proxy
+   /// </summary>
+   public class GMapImageProxy : PureImageProxy
+   {
+      private GMapImageProxy()
+      {
+      }
+
+      public static void Enable()
+      {
+         GMapProvider.TileImageProxy = Instance;
+      }
+
+      public static readonly GMapImageProxy Instance = new GMapImageProxy();
+
+      public override PureImage FromStream(Stream stream)
+      {
+         if (stream != null)
+         {
+            try
             {
-                Img = null;
-            }
+               var m = BitmapFrame.Create(stream,
+                  BitmapCreateOptions.IgnoreColorProfile,
+                  BitmapCacheOption.OnLoad);
 
-            if (Data != null)
+               var ret = new GMapImage {Img = m};
+               if (ret.Img.CanFreeze)
+               {
+                  ret.Img.Freeze();
+               }
+
+               return ret;
+            }
+            catch
             {
-                Data.Dispose();
-                Data = null;
+               stream.Position = 0;
+
+               int type = stream.Length > 0 ? stream.ReadByte() : 0;
+               Debug.WriteLine("WindowsPresentationImageProxy: unknown image format: " + type);
             }
-        }
-    }
+         }
 
-    /// <summary>
-    /// image abstraction proxy
-    /// </summary>
-    public class GMapImageProxy : PureImageProxy
-    {
-        private GMapImageProxy()
-        {
-        }
+         return null;
+      }
 
-        public static void Enable()
-        {
-            GMapProvider.TileImageProxy = Instance;
-        }
-
-        public static readonly GMapImageProxy Instance = new GMapImageProxy();
-
-        public override PureImage FromStream(Stream stream)
-        {
-            if (stream != null)
+      public override bool Save(Stream stream, PureImage image)
+      {
+         var ret = (GMapImage)image;
+         if (ret.Img != null)
+         {
+            try
             {
-                try
-                {
-                    var m = BitmapFrame.Create(stream,
-                        BitmapCreateOptions.IgnoreColorProfile,
-                        BitmapCacheOption.OnLoad);
+               var e = new PngBitmapEncoder();
+               e.Frames.Add(BitmapFrame.Create(ret.Img as BitmapSource));
+               e.Save(stream);
 
-                    var ret = new GMapImage {Img = m};
-                    if (ret.Img.CanFreeze)
-                    {
-                        ret.Img.Freeze();
-                    }
-
-                    return ret;
-                }
-                catch
-                {
-                    stream.Position = 0;
-
-                    int type = stream.Length > 0 ? stream.ReadByte() : 0;
-                    Debug.WriteLine("WindowsPresentationImageProxy: unknown image format: " + type);
-                }
+               return true;
             }
-
-            return null;
-        }
-
-        public override bool Save(Stream stream, PureImage image)
-        {
-            var ret = (GMapImage) image;
-            if (ret.Img != null)
+            catch
             {
-                try
-                {
-                    var e = new PngBitmapEncoder();
-                    e.Frames.Add(BitmapFrame.Create(ret.Img as BitmapSource));
-                    e.Save(stream);
-
-                    return true;
-                }
-                catch
-                {
-                    // ignore
-                }
+               // ignore
             }
+         }
 
-            return false;
-        }
-    }
+         return false;
+      }
+   }
 
-    //internal class TileVisual : FrameworkElement
-    //{
-    //    public readonly ObservableCollection<ImageSource> Source;
-    //    public readonly RawTile Tile;
+   //internal class TileVisual : FrameworkElement
+   //{
+   //    public readonly ObservableCollection<ImageSource> Source;
+   //    public readonly RawTile Tile;
 
-    //    public TileVisual(IEnumerable<ImageSource> src, RawTile tile)
-    //    {
-    //        Opacity = 0;
-    //        Tile = tile;
+   //    public TileVisual(IEnumerable<ImageSource> src, RawTile tile)
+   //    {
+   //        Opacity = 0;
+   //        Tile = tile;
 
-    //        Source = new ObservableCollection<ImageSource>(src);
-    //        Source.CollectionChanged += new System.Collections.Specialized.NotifyCollectionChangedEventHandler(Source_CollectionChanged);
+   //        Source = new ObservableCollection<ImageSource>(src);
+   //        Source.CollectionChanged += new System.Collections.Specialized.NotifyCollectionChangedEventHandler(Source_CollectionChanged);
 
-    //        this.Loaded += new RoutedEventHandler(ImageVisual_Loaded);
-    //        this.Unloaded += new RoutedEventHandler(ImageVisual_Unloaded);
-    //    }
+   //        this.Loaded += new RoutedEventHandler(ImageVisual_Loaded);
+   //        this.Unloaded += new RoutedEventHandler(ImageVisual_Unloaded);
+   //    }
 
-    //    void Source_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-    //    {
-    //        if (IsLoaded)
-    //        {
-    //            switch (e.Action)
-    //            {
-    //                case System.Collections.Specialized.NotifyCollectionChangedAction.Add:
-    //                case System.Collections.Specialized.NotifyCollectionChangedAction.Move:
-    //                case System.Collections.Specialized.NotifyCollectionChangedAction.Remove:
-    //                case System.Collections.Specialized.NotifyCollectionChangedAction.Replace:
-    //                {
-    //                    UpdateVisual();
-    //                }
-    //                break;
+   //    void Source_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+   //    {
+   //        if (IsLoaded)
+   //        {
+   //            switch (e.Action)
+   //            {
+   //                case System.Collections.Specialized.NotifyCollectionChangedAction.Add:
+   //                case System.Collections.Specialized.NotifyCollectionChangedAction.Move:
+   //                case System.Collections.Specialized.NotifyCollectionChangedAction.Remove:
+   //                case System.Collections.Specialized.NotifyCollectionChangedAction.Replace:
+   //                {
+   //                    UpdateVisual();
+   //                }
+   //                break;
 
-    //                case System.Collections.Specialized.NotifyCollectionChangedAction.Reset:
-    //                {
-    //                    Child = null;
-    //                }
-    //                break;
-    //            }
-    //        }
-    //    }
+   //                case System.Collections.Specialized.NotifyCollectionChangedAction.Reset:
+   //                {
+   //                    Child = null;
+   //                }
+   //                break;
+   //            }
+   //        }
+   //    }
 
-    //    void ImageVisual_Unloaded(object sender, RoutedEventArgs e)
-    //    {
-    //        Child = null;
-    //    }
+   //    void ImageVisual_Unloaded(object sender, RoutedEventArgs e)
+   //    {
+   //        Child = null;
+   //    }
 
-    //    void ImageVisual_Loaded(object sender, RoutedEventArgs e)
-    //    {
-    //        UpdateVisual();
-    //    }
+   //    void ImageVisual_Loaded(object sender, RoutedEventArgs e)
+   //    {
+   //        UpdateVisual();
+   //    }
 
-    //    Visual _child;
-    //    public virtual Visual Child
-    //    {
-    //        get
-    //        {
-    //            return _child;
-    //        }
-    //        set
-    //        {
-    //            if (_child != value)
-    //            {
-    //                if (_child != null)
-    //                {
-    //                    RemoveLogicalChild(_child);
-    //                    RemoveVisualChild(_child);
-    //                }
+   //    Visual _child;
+   //    public virtual Visual Child
+   //    {
+   //        get
+   //        {
+   //            return _child;
+   //        }
+   //        set
+   //        {
+   //            if (_child != value)
+   //            {
+   //                if (_child != null)
+   //                {
+   //                    RemoveLogicalChild(_child);
+   //                    RemoveVisualChild(_child);
+   //                }
 
-    //                if (value != null)
-    //                {
-    //                    AddVisualChild(value);
-    //                    AddLogicalChild(value);
-    //                }
+   //                if (value != null)
+   //                {
+   //                    AddVisualChild(value);
+   //                    AddLogicalChild(value);
+   //                }
 
-    //                // cache the new child
-    //                _child = value;
+   //                // cache the new child
+   //                _child = value;
 
-    //                InvalidateVisual();
-    //            }
-    //        }
-    //    }
+   //                InvalidateVisual();
+   //            }
+   //        }
+   //    }
 
-    //    public void UpdateVisual()
-    //    {
-    //        Child = Create();
-    //    }
+   //    public void UpdateVisual()
+   //    {
+   //        Child = Create();
+   //    }
 
-    //    static readonly Pen gridPen = new Pen(Brushes.White, 2.0);
+   //    static readonly Pen gridPen = new Pen(Brushes.White, 2.0);
 
-    //    private DrawingVisual Create()
-    //    {
-    //        var dv = new DrawingVisual();
+   //    private DrawingVisual Create()
+   //    {
+   //        var dv = new DrawingVisual();
 
-    //        using (DrawingContext dc = dv.RenderOpen())
-    //        {
-    //            foreach (var img in Source)
-    //            {
-    //                var rect = new Rect(0, 0, img.Width + 0.6, img.Height + 0.6);
+   //        using (DrawingContext dc = dv.RenderOpen())
+   //        {
+   //            foreach (var img in Source)
+   //            {
+   //                var rect = new Rect(0, 0, img.Width + 0.6, img.Height + 0.6);
 
-    //                dc.DrawImage(img, rect);
-    //                dc.DrawRectangle(null, gridPen, rect);
-    //            }
-    //        }
+   //                dc.DrawImage(img, rect);
+   //                dc.DrawRectangle(null, gridPen, rect);
+   //            }
+   //        }
 
-    //        return dv;
-    //    }
+   //        return dv;
+   //    }
 
-    //    #region Necessary Overrides -- Needed by WPF to maintain bookkeeping of our hosted visuals
-    //    protected override int VisualChildrenCount
-    //    {
-    //        get
-    //        {
-    //            return (Child == null ? 0 : 1);
-    //        }
-    //    }
+   //    #region Necessary Overrides -- Needed by WPF to maintain bookkeeping of our hosted visuals
+   //    protected override int VisualChildrenCount
+   //    {
+   //        get
+   //        {
+   //            return (Child == null ? 0 : 1);
+   //        }
+   //    }
 
-    //    protected override Visual GetVisualChild(int index)
-    //    {
-    //        Debug.Assert(index == 0);
-    //        return Child;
-    //    }
-    //    #endregion
-    //}
+   //    protected override Visual GetVisualChild(int index)
+   //    {
+   //        Debug.Assert(index == 0);
+   //        return Child;
+   //    }
+   //    #endregion
+   //}
 }

--- a/GMap.NET/GMap.NET.WindowsPresentation/GMap.NET.WindowsPresentation/GMapImage.cs
+++ b/GMap.NET/GMap.NET.WindowsPresentation/GMap.NET.WindowsPresentation/GMapImage.cs
@@ -1,284 +1,229 @@
 ﻿
 namespace GMap.NET.WindowsPresentation
 {
-   using System.Collections.Generic;
-   using System.Collections.ObjectModel;
-   using System.Diagnostics;
-   using System.Windows;
-   using System.Windows.Media;
-   using System.Windows.Media.Imaging;
-   using GMap.NET.Internals;
-   using GMap.NET.MapProviders;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Windows;
+    using System.Windows.Controls;
+    using System.Windows.Media;
+    using System.Windows.Media.Imaging;
+    using GMap.NET.Internals;
+    using GMap.NET.MapProviders;
 
-   /// <summary>
-   /// image abstraction
-   /// </summary>
-   public class GMapImage : PureImage
-   {
-      public ImageSource Img;
+    /// <summary>
+    /// image abstraction
+    /// </summary>
+    public class GMapImage : PureImage
+    {
+        public ImageSource Img;
 
-      public override void Dispose()
-      {
-         if(Img != null)
-         {
-            Img = null;
-         }
-
-         if(Data != null)
-         {
-            Data.Dispose();
-            Data = null;
-         }
-      }
-   }
-
-   /// <summary>
-   /// image abstraction proxy
-   /// </summary>
-   public class GMapImageProxy : PureImageProxy
-   {
-      GMapImageProxy()
-      {
-
-      }
-
-      public static void Enable()
-      {
-          GMapProvider.TileImageProxy = Instance;
-      }
-
-      public static readonly GMapImageProxy Instance = new GMapImageProxy();
-
-      //static readonly byte[] pngHeader = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-      //static readonly byte[] jpgHeader = { 0xFF, 0xD8, 0xFF };
-      //static readonly byte[] gifHeader = { 0x47, 0x49, 0x46 };
-      //static readonly byte[] bmpHeader = { 0x42, 0x4D };
-
-      public override PureImage FromStream(System.IO.Stream stream)
-      {
-         GMapImage ret = null;
-         if(stream != null)
-         {
-            var type = stream.ReadByte();
-            stream.Position = 0;
-
-            ImageSource m = null;
-
-            switch(type)
+        public override void Dispose()
+        {
+            if (Img != null)
             {
-               // PNG: 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
-               case 0x89:
-               {
-                  var bitmapDecoder = new PngBitmapDecoder(stream, BitmapCreateOptions.IgnoreColorProfile, BitmapCacheOption.OnLoad);
-                  m = bitmapDecoder.Frames[0];
-                  bitmapDecoder = null;
-               }
-               break;
-
-               // JPG: 0xFF, 0xD8, 0xFF
-               case 0xFF:
-               {
-                  var bitmapDecoder = new JpegBitmapDecoder(stream, BitmapCreateOptions.IgnoreColorProfile, BitmapCacheOption.OnLoad);
-                  m = bitmapDecoder.Frames[0];
-                  bitmapDecoder = null;
-               }
-               break;
-
-               // GIF: 0x47, 0x49, 0x46
-               case 0x47:
-               {
-                  var bitmapDecoder = new GifBitmapDecoder(stream, BitmapCreateOptions.IgnoreColorProfile, BitmapCacheOption.OnLoad);
-                  m = bitmapDecoder.Frames[0];
-                  bitmapDecoder = null;
-               }
-               break;
-
-               // BMP: 0x42, 0x4D
-               case 0x42:
-               {
-                  var bitmapDecoder = new BmpBitmapDecoder(stream, BitmapCreateOptions.IgnoreColorProfile, BitmapCacheOption.OnLoad);
-                  m = bitmapDecoder.Frames[0];
-                  bitmapDecoder = null;
-               }
-               break;
-
-               // TIFF: 0x49, 0x49 || 0x4D, 0x4D
-               case 0x49:
-               case 0x4D:
-               {
-                  var bitmapDecoder = new TiffBitmapDecoder(stream, BitmapCreateOptions.IgnoreColorProfile, BitmapCacheOption.OnLoad);
-                  m = bitmapDecoder.Frames[0];
-                  bitmapDecoder = null;
-               }
-               break;
-
-               default:
-               {
-                  Debug.WriteLine("WindowsPresentationImageProxy: unknown image format: " + type);
-               }
-               break;
+                Img = null;
             }
 
-            if(m != null)
+            if (Data != null)
             {
-               ret = new GMapImage();
-               ret.Img = m;
-               if(ret.Img.CanFreeze)
-               {
-                  ret.Img.Freeze();
-               }
+                Data.Dispose();
+                Data = null;
             }
-         }
-         return ret;
-      }
+        }
+    }
 
-      public override bool Save(System.IO.Stream stream, PureImage image)
-      {
-         GMapImage ret = (GMapImage)image;
-         if(ret.Img != null)
-         {
-            try
+    /// <summary>
+    /// image abstraction proxy
+    /// </summary>
+    public class GMapImageProxy : PureImageProxy
+    {
+        private GMapImageProxy()
+        {
+        }
+
+        public static void Enable()
+        {
+            GMapProvider.TileImageProxy = Instance;
+        }
+
+        public static readonly GMapImageProxy Instance = new GMapImageProxy();
+
+        public override PureImage FromStream(Stream stream)
+        {
+            if (stream != null)
             {
-               PngBitmapEncoder e = new PngBitmapEncoder();
-               e.Frames.Add(BitmapFrame.Create(ret.Img as BitmapSource));
-               e.Save(stream);
-               e = null;
+                try
+                {
+                    var m = BitmapFrame.Create(stream,
+                        BitmapCreateOptions.IgnoreColorProfile,
+                        BitmapCacheOption.OnLoad);
+
+                    var ret = new GMapImage {Img = m};
+                    if (ret.Img.CanFreeze)
+                    {
+                        ret.Img.Freeze();
+                    }
+
+                    return ret;
+                }
+                catch
+                {
+                    stream.Position = 0;
+
+                    int type = stream.Length > 0 ? stream.ReadByte() : 0;
+                    Debug.WriteLine("WindowsPresentationImageProxy: unknown image format: " + type);
+                }
             }
-            catch
+
+            return null;
+        }
+
+        public override bool Save(Stream stream, PureImage image)
+        {
+            var ret = (GMapImage) image;
+            if (ret.Img != null)
             {
-               return false;
+                try
+                {
+                    var e = new PngBitmapEncoder();
+                    e.Frames.Add(BitmapFrame.Create(ret.Img as BitmapSource));
+                    e.Save(stream);
+
+                    return true;
+                }
+                catch
+                {
+                    // ignore
+                }
             }
-         }
-         else
-         {
+
             return false;
-         }
+        }
+    }
 
-         return true;
-      }
-   }
+    //internal class TileVisual : FrameworkElement
+    //{
+    //    public readonly ObservableCollection<ImageSource> Source;
+    //    public readonly RawTile Tile;
 
-   //internal class TileVisual : FrameworkElement
-   //{
-   //    public readonly ObservableCollection<ImageSource> Source;
-   //    public readonly RawTile Tile;
+    //    public TileVisual(IEnumerable<ImageSource> src, RawTile tile)
+    //    {
+    //        Opacity = 0;
+    //        Tile = tile;
 
-   //    public TileVisual(IEnumerable<ImageSource> src, RawTile tile)
-   //    {
-   //        Opacity = 0;
-   //        Tile = tile;
+    //        Source = new ObservableCollection<ImageSource>(src);
+    //        Source.CollectionChanged += new System.Collections.Specialized.NotifyCollectionChangedEventHandler(Source_CollectionChanged);
 
-   //        Source = new ObservableCollection<ImageSource>(src);
-   //        Source.CollectionChanged += new System.Collections.Specialized.NotifyCollectionChangedEventHandler(Source_CollectionChanged);
+    //        this.Loaded += new RoutedEventHandler(ImageVisual_Loaded);
+    //        this.Unloaded += new RoutedEventHandler(ImageVisual_Unloaded);
+    //    }
 
-   //        this.Loaded += new RoutedEventHandler(ImageVisual_Loaded);
-   //        this.Unloaded += new RoutedEventHandler(ImageVisual_Unloaded);
-   //    }
+    //    void Source_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    //    {
+    //        if (IsLoaded)
+    //        {
+    //            switch (e.Action)
+    //            {
+    //                case System.Collections.Specialized.NotifyCollectionChangedAction.Add:
+    //                case System.Collections.Specialized.NotifyCollectionChangedAction.Move:
+    //                case System.Collections.Specialized.NotifyCollectionChangedAction.Remove:
+    //                case System.Collections.Specialized.NotifyCollectionChangedAction.Replace:
+    //                {
+    //                    UpdateVisual();
+    //                }
+    //                break;
 
-   //    void Source_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-   //    {
-   //        if (IsLoaded)
-   //        {
-   //            switch (e.Action)
-   //            {
-   //                case System.Collections.Specialized.NotifyCollectionChangedAction.Add:
-   //                case System.Collections.Specialized.NotifyCollectionChangedAction.Move:
-   //                case System.Collections.Specialized.NotifyCollectionChangedAction.Remove:
-   //                case System.Collections.Specialized.NotifyCollectionChangedAction.Replace:
-   //                {
-   //                    UpdateVisual();
-   //                }
-   //                break;
+    //                case System.Collections.Specialized.NotifyCollectionChangedAction.Reset:
+    //                {
+    //                    Child = null;
+    //                }
+    //                break;
+    //            }
+    //        }
+    //    }
 
-   //                case System.Collections.Specialized.NotifyCollectionChangedAction.Reset:
-   //                {
-   //                    Child = null;
-   //                }
-   //                break;
-   //            }
-   //        }
-   //    }
+    //    void ImageVisual_Unloaded(object sender, RoutedEventArgs e)
+    //    {
+    //        Child = null;
+    //    }
 
-   //    void ImageVisual_Unloaded(object sender, RoutedEventArgs e)
-   //    {
-   //        Child = null;
-   //    }
+    //    void ImageVisual_Loaded(object sender, RoutedEventArgs e)
+    //    {
+    //        UpdateVisual();
+    //    }
 
-   //    void ImageVisual_Loaded(object sender, RoutedEventArgs e)
-   //    {
-   //        UpdateVisual();
-   //    }
+    //    Visual _child;
+    //    public virtual Visual Child
+    //    {
+    //        get
+    //        {
+    //            return _child;
+    //        }
+    //        set
+    //        {
+    //            if (_child != value)
+    //            {
+    //                if (_child != null)
+    //                {
+    //                    RemoveLogicalChild(_child);
+    //                    RemoveVisualChild(_child);
+    //                }
 
-   //    Visual _child;
-   //    public virtual Visual Child
-   //    {
-   //        get
-   //        {
-   //            return _child;
-   //        }
-   //        set
-   //        {
-   //            if (_child != value)
-   //            {
-   //                if (_child != null)
-   //                {
-   //                    RemoveLogicalChild(_child);
-   //                    RemoveVisualChild(_child);
-   //                }
+    //                if (value != null)
+    //                {
+    //                    AddVisualChild(value);
+    //                    AddLogicalChild(value);
+    //                }
 
-   //                if (value != null)
-   //                {
-   //                    AddVisualChild(value);
-   //                    AddLogicalChild(value);
-   //                }
+    //                // cache the new child
+    //                _child = value;
 
-   //                // cache the new child
-   //                _child = value;
+    //                InvalidateVisual();
+    //            }
+    //        }
+    //    }
 
-   //                InvalidateVisual();
-   //            }
-   //        }
-   //    }
+    //    public void UpdateVisual()
+    //    {
+    //        Child = Create();
+    //    }
 
-   //    public void UpdateVisual()
-   //    {
-   //        Child = Create();
-   //    }
+    //    static readonly Pen gridPen = new Pen(Brushes.White, 2.0);
 
-   //    static readonly Pen gridPen = new Pen(Brushes.White, 2.0);
+    //    private DrawingVisual Create()
+    //    {
+    //        var dv = new DrawingVisual();
 
-   //    private DrawingVisual Create()
-   //    {
-   //        var dv = new DrawingVisual();
+    //        using (DrawingContext dc = dv.RenderOpen())
+    //        {
+    //            foreach (var img in Source)
+    //            {
+    //                var rect = new Rect(0, 0, img.Width + 0.6, img.Height + 0.6);
 
-   //        using (DrawingContext dc = dv.RenderOpen())
-   //        {
-   //            foreach (var img in Source)
-   //            {
-   //                var rect = new Rect(0, 0, img.Width + 0.6, img.Height + 0.6);
+    //                dc.DrawImage(img, rect);
+    //                dc.DrawRectangle(null, gridPen, rect);
+    //            }
+    //        }
 
-   //                dc.DrawImage(img, rect);
-   //                dc.DrawRectangle(null, gridPen, rect);
-   //            }
-   //        }
+    //        return dv;
+    //    }
 
-   //        return dv;
-   //    }
+    //    #region Necessary Overrides -- Needed by WPF to maintain bookkeeping of our hosted visuals
+    //    protected override int VisualChildrenCount
+    //    {
+    //        get
+    //        {
+    //            return (Child == null ? 0 : 1);
+    //        }
+    //    }
 
-   //    #region Necessary Overrides -- Needed by WPF to maintain bookkeeping of our hosted visuals
-   //    protected override int VisualChildrenCount
-   //    {
-   //        get
-   //        {
-   //            return (Child == null ? 0 : 1);
-   //        }
-   //    }
-
-   //    protected override Visual GetVisualChild(int index)
-   //    {
-   //        Debug.Assert(index == 0);
-   //        return Child;
-   //    }
-   //    #endregion
-   //}
+    //    protected override Visual GetVisualChild(int index)
+    //    {
+    //        Debug.Assert(index == 0);
+    //        return Child;
+    //    }
+    //    #endregion
+    //}
 }


### PR DESCRIPTION
Thanks for merging my previos PRs:)

Currently GMap.NET.Core is not working without the WinForms or WPF  package, because TileImageProxy is set in them.

In our project we don't need the WinForms or WPF control, I'd like to use the Core project without them for just getting the image tiles (data stream). With this PR GMaps has a default tile image proxy object which stores only the (Memory)stream. Of course it is overwritten with Winforms/WPF GMapImageProxy object when the control is used.

By the way, I noticed that the indent is mixed in the projects. In GMaps* projects it is usually 3 spaces, sometimes 4. Would you mind if I cleanup the code in the whole solution a little bit (indents, new lines, etc)? I'd prefer 4 spaces, since it is the default nowadays, but I can use 3 if you prefer that.