### PR TITLE
Support sending X-Yours-Client header via OSMProvider

### DIFF
--- a/GMap.NET/GMap.NET.Core/MapProviders/GMapProvider.cs
+++ b/GMap.NET/GMap.NET.Core/MapProviders/GMapProvider.cs
@@ -469,6 +469,8 @@ namespace GMap.NET.MapProviders
             _authorization = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(userName + ":" + userPassword));
         }
 
+        protected virtual void InitializeWebRequest(WebRequest request) { }
+
         protected PureImage GetTileImageUsingHttp(string url)
         {
             PureImage ret = null;
@@ -518,6 +520,8 @@ namespace GMap.NET.MapProviders
                     r.Headers.Add("Referer", RefererUrl);
                 }
             }
+
+            InitializeWebRequest(request);
 
             using (var response = request.GetResponse())
             {
@@ -607,6 +611,8 @@ namespace GMap.NET.MapProviders
                     r.Headers.Add("Referer", RefererUrl);
                 }
             }
+
+            InitializeWebRequest(request);
 
             WebResponse response;
 

--- a/GMap.NET/GMap.NET.Core/MapProviders/OpenStreetMap/OpenStreetMapProvider.cs
+++ b/GMap.NET/GMap.NET.Core/MapProviders/OpenStreetMap/OpenStreetMapProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Net;
 using System.Xml;
 using GMap.NET.Internals;
 using GMap.NET.Projections;
@@ -560,6 +561,8 @@ namespace GMap.NET.MapProviders
             get;
         } = "OpenStreetMap";
 
+        public string YoursClientName { get; set; }
+
         GMapProvider[] _overlays;
 
         public override GMapProvider[] Overlays
@@ -580,6 +583,16 @@ namespace GMap.NET.MapProviders
             string url = MakeTileImageUrl(pos, zoom, string.Empty);
 
             return GetTileImageUsingHttp(url);
+        }
+
+        protected override void InitializeWebRequest(WebRequest request)
+        {
+            base.InitializeWebRequest(request);
+
+            if (!string.IsNullOrEmpty(YoursClientName))
+            {
+                request.Headers.Add("X-Yours-client", YoursClientName);
+            }
         }
 
         #endregion


### PR DESCRIPTION
## Changes

- Adds a new protected virtual member `InitializeWebRequest` in the generic `GMapProvider`
- Adds a new property `YoursClientName` in `OpenStreetMapProvider` to allow users to set the name
- Overrides `InitializeWebRequest` in `OpenStreetMapProvider` to add the `X-Yours-client` header if `YoursClientName` is set

---

Look forward to your thoughts

Fixes #84