### PR TITLE
Changed _core._position to Position

### DIFF
--- a/GMap.NET/GMap.NET.WindowsPresentation/GMapControl.cs
+++ b/GMap.NET/GMap.NET.WindowsPresentation/GMapControl.cs
@@ -1737,15 +1737,15 @@ namespace GMap.NET.WindowsPresentation
                 {
                     if (MouseWheelZoomType == MouseWheelZoomType.MousePositionAndCenter)
                     {
-                        _core._position = FromLocalToLatLng((int)p.X, (int)p.Y);
+                        Position = FromLocalToLatLng((int)p.X, (int)p.Y);
                     }
                     else if (MouseWheelZoomType == MouseWheelZoomType.ViewCenter)
                     {
-                        _core._position = FromLocalToLatLng((int)ActualWidth / 2, (int)ActualHeight / 2);
+                        Position = FromLocalToLatLng((int)ActualWidth / 2, (int)ActualHeight / 2);
                     }
                     else if (MouseWheelZoomType == MouseWheelZoomType.MousePositionWithoutCenter)
                     {
-                        _core._position = FromLocalToLatLng((int)p.X, (int)p.Y);
+                        Position = FromLocalToLatLng((int)p.X, (int)p.Y);
                     }
 
                     _core.MouseLastZoom.X = (int)p.X;


### PR DESCRIPTION
When zooming off-center with MouseWheelZoomType == MouseWheelZoomType.MousePositionAndCenter or MouseWheelZoomType == MouseWheelZoomType.MousePositionWithoutCenter, the Position should be changed as well. it turns out, the _core._position is the one being changed, that is why the user is being notified of such changes.