### PR TITLE
A Threadsafe enumeration of ObservableCollection

### DIFF
--- a/GMap.NET/GMap.NET.Core/PureProjection.cs
+++ b/GMap.NET/GMap.NET.Core/PureProjection.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using System.Linq;
 using static System.Math;
 
 namespace GMap.NET
@@ -218,7 +219,7 @@ namespace GMap.NET
         /// </summary>
         public List<GPoint> GetAreaTileList(RectLatLng rect, int zoom, int padding)
         {
-            var ret = new List<GPoint>();
+            var set = new HashSet<GPoint>();
 
             var topLeft = FromPixelToTileXY(FromLatLngToPixel(rect.LocationTopLeft, zoom));
             var rightBottom = FromPixelToTileXY(FromLatLngToPixel(rect.LocationRightBottom, zoom));
@@ -228,14 +229,18 @@ namespace GMap.NET
                 for (long y = topLeft.Y - padding; y <= rightBottom.Y + padding; y++)
                 {
                     var p = new GPoint(x, y);
-                    if (!ret.Contains(p) && p.X >= 0 && p.Y >= 0)
+                    if (!set.Contains(p) && p.X >= 0 && p.Y >= 0)
+                    {
+                        set.Add(p);
+                    }
+                    /*if (!ret.Contains(p) && p.X >= 0 && p.Y >= 0)
                     {
                         ret.Add(p);
-                    }
+                    }*/
                 }
             }
 
-            return ret;
+            return set.ToList();
         }
 
         /// <summary>

--- a/GMap.NET/GMap.NET.WindowsForms/GMap.NET.ObjectModel/ThreadSafeEnumerator.cs
+++ b/GMap.NET/GMap.NET.WindowsForms/GMap.NET.ObjectModel/ThreadSafeEnumerator.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace GMap.NET.ObjectModel
+{
+    public class ThreadSafeEnumerator<T> : IEnumerator<T>
+    {
+        // this is the (thread-unsafe)
+        // enumerator of the underlying collection
+        private readonly IEnumerator<T> m_Inner;
+        // this is the object we shall lock on. 
+        private readonly object m_Lock;
+
+        public ThreadSafeEnumerator(IEnumerator<T> inner, object @lock)
+        {
+            m_Inner = inner;
+            m_Lock = @lock;
+            // entering lock in constructor
+            Monitor.Enter(m_Lock);
+        }
+
+        #region Implementation of IDisposable
+
+        public void Dispose()
+        {
+            // .. and exiting lock on Dispose()
+            // This will be called when foreach loop finishes
+            Monitor.Exit(m_Lock);
+        }
+
+        #endregion
+
+        #region Implementation of IEnumerator
+
+        // we just delegate actual implementation
+        // to the inner enumerator, that actually iterates
+        // over some collection
+
+        public bool MoveNext()
+        {
+            return m_Inner.MoveNext();
+        }
+
+        public void Reset()
+        {
+            m_Inner.Reset();
+        }
+
+        public T Current
+        {
+            get { return m_Inner.Current; }
+        }
+
+        object IEnumerator.Current
+        {
+            get { return Current; }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
In a multi threaded application I ran into an 'collection has been modified' exception when one thread adds markers to or removes markers from an overlay while the control enumerats that collection of markers to update the UI.

This implementation of a Threadsafe Enumerator was inspired by a CodeProject article and solves my situation. Altough the exception was very rare (I isolated adding and removing to the most short timeframe), a fatal at runtime and complex code in the mulit threaded application to avoid the issue is not really diserable.

Prefetching a large viewarea with a high zoom level the PureProjection.GetAreaTileList can better use a HashSet instead of a List<>. Checking a HashSet for existence of a GPoint is considerable faster than in a List<> (which has to go thru the entire list). With more then 50.000 points, the List<> gets very slow.