### PR TITLE
Updated dependencies and .net framework 4.8

### DIFF
--- a/Demo.Testing/App.config
+++ b/Demo.Testing/App.config
@@ -13,6 +13,14 @@
       <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
     </providers>
   </entityFramework>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.115.5" newVersion="1.0.115.5" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
   <system.data>
     <DbProviderFactories>
       <remove invariant="System.Data.SQLite.EF6" />

--- a/Demo.Testing/Demo.Testing.csproj
+++ b/Demo.Testing/Demo.Testing.csproj
@@ -45,14 +45,14 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.SQLite, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\lib\net46\System.Data.SQLite.dll</HintPath>
+    <Reference Include="System.Data.SQLite, Version=1.0.115.5, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\lib\net46\System.Data.SQLite.dll</HintPath>
     </Reference>
-    <Reference Include="System.Data.SQLite.EF6, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.113.0\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
+    <Reference Include="System.Data.SQLite.EF6, Version=1.0.115.5, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.115.5\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
     </Reference>
-    <Reference Include="System.Data.SQLite.Linq, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.113.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
+    <Reference Include="System.Data.SQLite.Linq, Version=1.0.115.5, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.115.5\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -116,8 +116,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.props'))" />
     <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.targets'))" />
-    <Error Condition="!Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets'))" />
+    <Error Condition="!Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets'))" />
   </Target>
   <Import Project="..\packages\EntityFramework.6.4.4\build\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" />
-  <Import Project="..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets" Condition="Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" />
+  <Import Project="..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets" Condition="Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" />
 </Project>

--- a/Demo.Testing/packages.config
+++ b/Demo.Testing/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.4.4" targetFramework="net48" />
-  <package id="Stub.System.Data.SQLite.Core.NetFramework" version="1.0.113.3" targetFramework="net48" />
-  <package id="System.Data.SQLite" version="1.0.113.7" targetFramework="net48" />
-  <package id="System.Data.SQLite.Core" version="1.0.113.7" targetFramework="net48" />
-  <package id="System.Data.SQLite.EF6" version="1.0.113.0" targetFramework="net48" />
-  <package id="System.Data.SQLite.Linq" version="1.0.113.0" targetFramework="net48" />
+  <package id="Stub.System.Data.SQLite.Core.NetFramework" version="1.0.115.5" targetFramework="net48" />
+  <package id="System.Data.SQLite" version="1.0.115.5" targetFramework="net48" />
+  <package id="System.Data.SQLite.Core" version="1.0.115.5" targetFramework="net48" />
+  <package id="System.Data.SQLite.EF6" version="1.0.115.5" targetFramework="net48" />
+  <package id="System.Data.SQLite.Linq" version="1.0.115.5" targetFramework="net48" />
 </packages>

--- a/Demo/Demo.WindowsForms/Demo.WindowsForms.csproj
+++ b/Demo/Demo.WindowsForms/Demo.WindowsForms.csproj
@@ -4,7 +4,7 @@
         <AssemblyTitle>Demo.WindowsForms</AssemblyTitle>
         <Description>Demo for GMap.NET.WindowsForms</Description>
         <Product>Demo.WindowsForms</Product>
-        <TargetFrameworks>net46;net5.0-windows</TargetFrameworks>
+        <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
         <UseWindowsForms>true</UseWindowsForms>
         <OutputType>WinExe</OutputType>
         <SignAssembly>True</SignAssembly>
@@ -23,7 +23,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Data.SQLite" Version="1.0.113.7" />
+        <PackageReference Include="System.Data.SQLite" Version="1.0.115.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Demo/Demo.WindowsPresentation/Demo.WindowsPresentation.csproj
+++ b/Demo/Demo.WindowsPresentation/Demo.WindowsPresentation.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Demo.WindowsPresentation</AssemblyTitle>
     <Description>Demo for GMap.NET.WindowsPresentation</Description>
     <Product>Demo.WindowsPresentation</Product>
-    <TargetFrameworks>net46;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <OutputType>WinExe</OutputType>
     <SignAssembly>True</SignAssembly>

--- a/GMap.NET/GMap.NET.Core/GMap.NET.Core.csproj
+++ b/GMap.NET/GMap.NET.Core/GMap.NET.Core.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>GMap.NET.Core</AssemblyTitle>
     <RootNamespace>GMap.NET</RootNamespace>
 
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>    
+    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>    
     <DefineConstants>MONO_disabled;SQLite;MySQL_disabled;PostgreSQL_disabled;$(DefineConstants)</DefineConstants>
     
     <PackageReleaseNotes>
@@ -18,18 +18,18 @@ https://github.com/judero01col/GMap.NET/blob/master/README.md#release-notes
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.113.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.115.5" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Data.SqlClient">
-      <Version>4.7.0</Version>
+      <Version>4.8.3</Version>
     </PackageReference>
     <PackageReference Include="System.Security.Principal.Windows">
-      <Version>4.6.0</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/GMap.NET/GMap.NET.Windows/GMap.NET.Windows.csproj
+++ b/GMap.NET/GMap.NET.Windows/GMap.NET.Windows.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>GMap.NET.Windows</AssemblyTitle>
 
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
 
     <PackageReleaseNotes>
 Library migrated to .Net Core and published in new individual packages

--- a/GMap.NET/GMap.NET.WindowsForms/GMap.NET.WindowsForms.csproj
+++ b/GMap.NET/GMap.NET.WindowsForms/GMap.NET.WindowsForms.csproj
@@ -5,7 +5,7 @@
     <Product>GMap.NET.WindowsForms</Product>
     <AssemblyTitle>GMap.NET.WindowsForms</AssemblyTitle>
     
-    <TargetFrameworks>net46;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <DefineConstants>ContinuesMapNo;$(DefineConstants)</DefineConstants>
     

--- a/GMap.NET/GMap.NET.WindowsPresentation/GMap.NET.WindowsPresentation.csproj
+++ b/GMap.NET/GMap.NET.WindowsPresentation/GMap.NET.WindowsPresentation.csproj
@@ -5,7 +5,7 @@
     <Product>GMap.NET.WindowsPresentation</Product>
     <AssemblyTitle>GMap.NET.WindowsPresentation</AssemblyTitle>
     
-    <TargetFrameworks>net46;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     
     <PackageReleaseNotes>

--- a/Testing/BigMapMaker/BigMapMaker.csproj
+++ b/Testing/BigMapMaker/BigMapMaker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/Testing/BingWpfFusion/BingWpfFusion.csproj
+++ b/Testing/BingWpfFusion/BingWpfFusion.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <OutputType>WinExe</OutputType>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/Testing/ConsoleApplication/ConsoleApplication.csproj
+++ b/Testing/ConsoleApplication/ConsoleApplication.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;net5.0</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../sn.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotSpatial.Projections" Version="1.9.0" />
+    <PackageReference Include="DotSpatial.Projections" Version="4.0.656" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Testing/Demo.Clouds/Demo.Clouds.csproj
+++ b/Testing/Demo.Clouds/Demo.Clouds.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <OutputType>WinExe</OutputType>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/Testing/Demo.Docking/Demo.Docking.csproj
+++ b/Testing/Demo.Docking/Demo.Docking.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <OutputType>WinExe</OutputType>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/Testing/Demo.Geocoding/Demo.Geocoding.csproj
+++ b/Testing/Demo.Geocoding/Demo.Geocoding.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <OutputType>WinExe</OutputType>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/Testing/Demo.StreetView/Demo.StreetView.csproj
+++ b/Testing/Demo.StreetView/Demo.StreetView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>

--- a/Testing/MvcMapFusion/MvcMapFusion.csproj
+++ b/Testing/MvcMapFusion/MvcMapFusion.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <OutputType>Library</OutputType>
     <OutputPath>bin\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\..\GMap.NET\GMap.NET.WindowsPresentation\GMap.NET.WindowsPresentation.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <Reference Include="System.Web" />
   </ItemGroup>
 
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SQLite" Version="1.0.113.7" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.115.5" />
   </ItemGroup>
 
 </Project>

--- a/Testing/Silverlight/SilverlightMapFusion.Web/SilverlightMapFusion.Web.csproj
+++ b/Testing/Silverlight/SilverlightMapFusion.Web/SilverlightMapFusion.Web.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SilverlightMapFusion.Web</RootNamespace>
     <AssemblyName>SilverlightMapFusion.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <SilverlightApplicationList>{9407D648-C4FC-4A84-821A-F5275E10FA1E}|..\SilverlightMapFusion\SilverlightMapFusion.csproj|ClientBin|False</SilverlightApplicationList>
     <FileUpgradeFlags>
@@ -27,6 +27,7 @@
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
     <Use64BitIISExpress />
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -47,21 +48,20 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="ClientBin\SilverlightMapFusion.xap" />

--- a/Testing/Silverlight/SilverlightMapFusion.Web/Web.config
+++ b/Testing/Silverlight/SilverlightMapFusion.Web/Web.config
@@ -1,13 +1,18 @@
 ﻿<?xml version="1.0"?>
-
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433
   -->
-
 <configuration>
-    <system.web>
-        <compilation debug="true" targetFramework="4.0" />
-    </system.web>
+  <!--
+    Per una descrizione delle modifiche al file web.config, vedere il sito Web all'indirizzo http://go.microsoft.com/fwlink/?LinkId=235367.
 
+    Gli attributi seguenti possono essere impostati sul tag <httpRuntime>.
+      <system.Web>
+        <httpRuntime targetFramework="4.8" />
+      </system.Web>
+  -->
+  <system.web>
+    <compilation debug="true" targetFramework="4.8"/>
+  </system.web>
 </configuration>

--- a/Testing/TemplatedBinding/TemplatedBinding.csproj
+++ b/Testing/TemplatedBinding/TemplatedBinding.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <OutputType>WinExe</OutputType>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/Tools/MapCruncher/MapCruncher.csproj
+++ b/Tools/MapCruncher/MapCruncher.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <OutputType>WinExe</OutputType>


### PR DESCRIPTION
Updated all projects from .net framework 4.6 to 4.8 and updated all nuget dependencies to latest available.
This was particularly important because System.Data.SQLClient is not available in the version that was referenced and by using an updated version it was not working in WinForms (I suspect due to mixed mode assembly that has to match version of the non managed code).

All projects compiles (VS2019) and are working correctly.

NOTE: i've not changed version of libraries so that I let you choose how to numerate them and publish to nuget with updated versions.