### PR TITLE
GrayScaleMode support for WPF .NET Frameworks projects

### DIFF
--- a/GMap.NET/GMap.NET.WindowsPresentation/ColorMatrixs.cs
+++ b/GMap.NET/GMap.NET.WindowsPresentation/ColorMatrixs.cs
@@ -1,0 +1,23 @@
+﻿#if NETFRAMEWORK && !NET5_0_OR_GREATER
+using System.Drawing.Imaging;
+#endif
+
+namespace GMap.NET.WindowsPresentation
+{
+#if NETFRAMEWORK && !NET5_0_OR_GREATER
+    public static class ColorMatrixs
+    {
+        public static readonly ColorMatrix GrayScale = new ColorMatrix(new[]
+        {
+            new[] {.3f, .3f, .3f, 0, 0}, new[] {.59f, .59f, .59f, 0, 0},
+            new[] {.11f, .11f, .11f, 0, 0}, new float[] {0, 0, 0, 1, 0}, new float[] {0, 0, 0, 0, 1}
+        });
+
+        public static readonly ColorMatrix Negative = new ColorMatrix(new[]
+        {
+            new float[] {-1, 0, 0, 0, 0}, new float[] {0, -1, 0, 0, 0}, new float[] {0, 0, -1, 0, 0},
+            new float[] {0, 0, 0, 1, 0}, new float[] {1, 1, 1, 0, 1}
+        });
+    }
+#endif
+}

--- a/GMap.NET/GMap.NET.WindowsPresentation/GMapControl.cs
+++ b/GMap.NET/GMap.NET.WindowsPresentation/GMapControl.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
+#if NETFRAMEWORK && !NET5_0_OR_GREATER
+using System.Drawing.Imaging;
+#endif
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -406,6 +409,64 @@ namespace GMap.NET.WindowsPresentation
         private ScaleModes _scaleMode = ScaleModes.Integer;
 
         #endregion
+
+#if NETFRAMEWORK && !NET5_0_OR_GREATER
+        private bool _grayScale;
+
+        [Category("GMap.NET")]
+        public bool GrayScaleMode
+        {
+            get
+            {
+                return _grayScale;
+            }
+            set
+            {
+                _grayScale = value;
+                ColorMatrix = value ? ColorMatrixs.GrayScale : null;
+            }
+        }
+
+        private bool _negative;
+
+        [Category("GMap.NET")]
+        public bool NegativeMode
+        {
+            get
+            {
+                return _negative;
+            }
+            set
+            {
+                _negative = value;
+                ColorMatrix = value ? ColorMatrixs.Negative : null;
+            }
+        }
+
+        ColorMatrix _colorMatrix;
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
+        public ColorMatrix ColorMatrix
+        {
+            get
+            {
+                return _colorMatrix;
+            }
+            set
+            {
+                _colorMatrix = value;
+                if (GMapProvider.TileImageProxy != null && GMapProvider.TileImageProxy is GMapImageProxy)
+                {
+                    (GMapProvider.TileImageProxy as GMapImageProxy).ColorMatrix = value;
+                    if (_core != null && _core.IsStarted)
+                    {
+                        ReloadMap();
+                    }
+                }
+            }
+        }
+#endif
 
         readonly Core _core = new Core();
 


### PR DESCRIPTION
Added missing GrayScaleMode and NegativeMode properties known from GMap.NET.WindowsForms version to WPF .NET Frameworks projects