### PR TITLE
Fix x64 crash: memory addresses are 64 bit integers

### DIFF
--- a/Tools/MapCruncher/MSR.CVE.BackMaker.ImagePipeline/WPFOpenDocument.cs
+++ b/Tools/MapCruncher/MSR.CVE.BackMaker.ImagePipeline/WPFOpenDocument.cs
@@ -119,7 +119,7 @@ namespace MSR.CVE.BackMaker.ImagePipeline
                                 System.Drawing.Imaging.PixelFormat.Format32bppArgb);
                             try
                             {
-                                IntPtr buffer = new IntPtr(bitmapData.Scan0.ToInt32() +
+                                IntPtr buffer = new IntPtr(bitmapData.Scan0.ToInt64() +
                                                            int32Rect.Y * bitmapData.Stride + int32Rect.X * 4);
                                 bitmapSource.CopyPixels(
                                     new Int32Rect(0, 0, bitmapSource.PixelWidth, bitmapSource.PixelHeight),


### PR DESCRIPTION
If the application is built as a 64-bit application, using Scan0.ToInt32() will cause a "Arithmetic operation resulted in an overflow" exception when converting a 64-bit memory address to 32-bit integer