### PR TITLE
WindowsPresentation.GMapControl: Unsubscribe OnCurrentPositionChanged to prevent Memory Leak

### DIFF
--- a/GMap.NET/GMap.NET.Avalonia/GMapControl.cs
+++ b/GMap.NET/GMap.NET.Avalonia/GMapControl.cs
@@ -2269,6 +2269,7 @@ namespace GMap.NET.Avalonia
             if (_core.IsStarted)
             {
                 _core.OnMapZoomChanged -= ForceUpdateOverlays;
+                _core.OnCurrentPositionChanged -= CoreOnCurrentPositionChanged;
                 _core.OnMapClose();
             }
         }

--- a/GMap.NET/GMap.NET.WindowsPresentation/GMapControl.cs
+++ b/GMap.NET/GMap.NET.WindowsPresentation/GMapControl.cs
@@ -2850,6 +2850,7 @@ namespace GMap.NET.WindowsPresentation
             if (_core.IsStarted)
             {
                 _core.OnMapZoomChanged -= ForceUpdateOverlays;
+                _core.OnCurrentPositionChanged -= CoreOnCurrentPositionChanged;
                 Loaded -= GMapControl_Loaded;
                 Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
                 SizeChanged -= GMapControl_SizeChanged;


### PR DESCRIPTION
In Constructor of `WindowsPresentation.GMapControl` the OnCurrentPositionChanged event of _core is subscribed. But this subscription is never deleted, even when the control is disposed. This can lead to memory leaks and should be fixed.